### PR TITLE
Popsize argument in EvolutionaryOptimizer in likelihood.py

### DIFF
--- a/src/jimgw/likelihood.py
+++ b/src/jimgw/likelihood.py
@@ -378,7 +378,7 @@ class HeterodynedTransientLikelihoodFD(TransientLikelihoodFD):
         y = jax.jit(jax.vmap(y))
 
         print("Starting the optimizer")
-        optimizer = EvolutionaryOptimizer(len(bounds), verbose=True)
+        optimizer = EvolutionaryOptimizer(len(bounds), popsize=set_nwalkers, verbose=True)
         state = optimizer.optimize(y, bounds, n_loops=n_loops)
         best_fit = optimizer.get_result()[0]
         return prior.add_name(best_fit, transform_name=True, transform_value=True)

--- a/src/jimgw/likelihood.py
+++ b/src/jimgw/likelihood.py
@@ -143,7 +143,7 @@ class HeterodynedTransientLikelihoodFD(TransientLikelihoodFD):
         trigger_time: float = 0,
         duration: float = 4,
         post_trigger_duration: float = 2,
-        n_walkers: int = 100,
+        popsize: int = 100,
         n_loops: int = 2000,
     ) -> None:
         super().__init__(
@@ -157,7 +157,7 @@ class HeterodynedTransientLikelihoodFD(TransientLikelihoodFD):
         self.freq_grid_low = freq_grid[:-1]
 
         self.ref_params = self.maximize_likelihood(
-            bounds=bounds, prior=prior, set_nwalkers=n_walkers, n_loops=n_loops
+            bounds=bounds, prior=prior, popsize=popsize, n_loops=n_loops
         )
 
         self.ref_params["gmst"] = self.gmst
@@ -366,11 +366,11 @@ class HeterodynedTransientLikelihoodFD(TransientLikelihoodFD):
         self,
         bounds: tuple[Array, Array],
         prior: Prior,
-        set_nwalkers: int = 100,
+        popsize: int = 100,
         n_loops: int = 2000,
     ):
         bounds = jnp.array(bounds).T
-        set_nwalkers = set_nwalkers # TODO remove this?
+        popsize = popsize # TODO remove this?
 
         y = lambda x: -self.evaluate_original(
             prior.add_name(x, transform_name=True, transform_value=True), None
@@ -378,7 +378,7 @@ class HeterodynedTransientLikelihoodFD(TransientLikelihoodFD):
         y = jax.jit(jax.vmap(y))
 
         print("Starting the optimizer")
-        optimizer = EvolutionaryOptimizer(len(bounds), popsize=set_nwalkers, verbose=True)
+        optimizer = EvolutionaryOptimizer(len(bounds), popsize=popsize, verbose=True)
         state = optimizer.optimize(y, bounds, n_loops=n_loops)
         best_fit = optimizer.get_result()[0]
         return prior.add_name(best_fit, transform_name=True, transform_value=True)

--- a/src/jimgw/likelihood.py
+++ b/src/jimgw/likelihood.py
@@ -370,7 +370,7 @@ class HeterodynedTransientLikelihoodFD(TransientLikelihoodFD):
         n_loops: int = 2000,
     ):
         bounds = jnp.array(bounds).T
-        set_nwalkers = set_nwalkers
+        set_nwalkers = set_nwalkers # TODO remove this?
 
         y = lambda x: -self.evaluate_original(
             prior.add_name(x, transform_name=True, transform_value=True), None


### PR DESCRIPTION
I have just noticed that, when calling the `EvolutionaryOptimizer` from jim's `HeterodynedTransientLikelihoodFD`, the argument `set_nwalkers` is unused, which I believe is supposed to represent the `popsize` argument of the `EvolutionaryOptimizer`. I have also renamed this variable to `popsize` in `likelihood.py` to avoid confusion. 