### PR TITLE
Assured frequency grids have same length in relative binning

### DIFF
--- a/src/jimgw/likelihood.py
+++ b/src/jimgw/likelihood.py
@@ -223,6 +223,10 @@ class HeterodynedTransientLikelihoodFD(TransientLikelihoodFD):
         self.freq_grid_low = self.freq_grid_low[mask_heterodyne_low]
         self.freq_grid_center = self.freq_grid_center[mask_heterodyne_center]
 
+        # Assure frequency grids have same length
+        if len(self.freq_grid_low) > len(self.freq_grid_center):
+            self.freq_grid_low = self.freq_grid_low[:len(self.freq_grid_center)]
+
         h_sky_low = self.waveform(self.freq_grid_low, self.ref_params)
         h_sky_center = self.waveform(self.freq_grid_center, self.ref_params)
 


### PR DESCRIPTION
I have noticed there is a small bug in the `HeterodynedTransientLikelihoodFD`. It can happen that there is an index `i` for which `self.freq_grid_low[i] < fmax < self.freq_grid_center[i]`, triggering a shape mismatch error in the computations of the subsequent relative binning code. I have added a few lines of code to discard the final entry of `self.freq_grid_center` in case this happens, and have verified that this solves the error. 