### PR TITLE
Handling nan output from Adam optimizer when generating reference parameters

### DIFF
--- a/src/jimgw/single_event/likelihood.py
+++ b/src/jimgw/single_event/likelihood.py
@@ -559,7 +559,7 @@ class HeterodynedTransientLikelihoodFD(TransientLikelihoodFD):
         rng_key, optimized_positions, summary = optimizer.optimize(
             jax.random.PRNGKey(12094), y, initial_position
         )
-        best_fit = optimized_positions[summary["final_log_prob"].argmin()]
+        best_fit = optimized_positions[jnp.nanargmin(summary["final_log_prob"])]
         return prior.transform(prior.add_name(best_fit))
 
 


### PR DESCRIPTION
When trying to generate a set of reference parameters for the heterodyning likelihood, the output list of log likelihood often contains some `nan` values. When we try to search for the minimum log likelihood using `argmin()` on a list containing `nan` values, it will result in a list of `nan` as the reference parameters, causing the program to run into a bug. I think it would be a better idea to replace `argmin()` with `nanargmin()`. This will allow the code to search for the minimum log likelihood while ignoring the `nan` values. This approach will enable the code to proceed, but it should still output a warning to notify the user that `nan` values were present in the log likelihood list.

