### PR TITLE
Allowing user to keep parameters after the likelihood transform

### DIFF
--- a/src/jimgw/jim.py
+++ b/src/jimgw/jim.py
@@ -112,6 +112,10 @@ class Jim(object):
                     guess = self.prior.sample(key, 1)
                     for transform in self.sample_transforms:
                         guess = transform.forward(guess)
+                        jax.tree.map(
+                            lambda key: guess.pop(key),
+                            transform.name_mapping[0],
+                        )
                     guess = jnp.array([i for i in guess.values()]).T[0]
                     flag = not jnp.all(jnp.isfinite(guess))
                 initial_guess.append(guess)

--- a/src/jimgw/jim.py
+++ b/src/jimgw/jim.py
@@ -24,6 +24,7 @@ class Jim(object):
     likelihood_transforms: list[NtoMTransform]
     parameter_names: list[str]
     sampler: Sampler
+    parameters_to_keep: list[str]
 
     def __init__(
         self,
@@ -31,6 +32,7 @@ class Jim(object):
         prior: Prior,
         sample_transforms: list[BijectiveTransform] = [],
         likelihood_transforms: list[NtoMTransform] = [],
+        parameters_to_keep: list[str] = [],
         **kwargs,
     ):
         self.likelihood = likelihood
@@ -39,6 +41,7 @@ class Jim(object):
         self.sample_transforms = sample_transforms
         self.likelihood_transforms = likelihood_transforms
         self.parameter_names = prior.parameter_names
+        self.parameters_to_keep = parameters_to_keep
 
         if len(sample_transforms) == 0:
             print(
@@ -98,8 +101,17 @@ class Jim(object):
             named_params, jacobian = transform.inverse(named_params)
             transform_jacobian += jacobian
         prior = self.prior.log_prob(named_params) + transform_jacobian
+
+        # make a copy of the named_params
+        named_params_copy = named_params.copy()
+        # do the likelihood transform
         for transform in self.likelihood_transforms:
             named_params = transform.forward(named_params)
+        # add back the parameters
+        jax.tree.map(
+            lambda key: named_params.update({key: named_params_copy[key]}),
+            self.parameters_to_keep,
+        )
         return self.likelihood.evaluate(named_params, data) + prior
 
     def sample(self, key: PRNGKeyArray, initial_position: Array = jnp.array([])):

--- a/src/jimgw/prior.py
+++ b/src/jimgw/prior.py
@@ -190,6 +190,11 @@ class SequentialTransformPrior(Prior):
     def transform(self, x: dict[str, Float]) -> dict[str, Float]:
         for transform in self.transforms:
             x = transform.forward(x)
+            # poping the original parameters
+            jax.tree.map(
+                lambda key: x.pop(key),
+                transform.name_mapping[0],
+            )
         return x
 
 

--- a/src/jimgw/single_event/likelihood.py
+++ b/src/jimgw/single_event/likelihood.py
@@ -196,7 +196,6 @@ class HeterodynedTransientLikelihoodFD(TransientLikelihoodFD):
         prior: Optional[Prior] = None,
         sample_transforms: list[BijectiveTransform] = [],
         likelihood_transforms: list[NtoMTransform] = [],
-        parameters_to_keep: list[str] = [],
         **kwargs,
     ) -> None:
         super().__init__(
@@ -266,7 +265,6 @@ class HeterodynedTransientLikelihoodFD(TransientLikelihoodFD):
                 prior=prior,
                 sample_transforms=sample_transforms,
                 likelihood_transforms=likelihood_transforms,
-                parameters_to_keep=parameters_to_keep,
                 popsize=popsize,
                 n_steps=n_steps,
             )
@@ -555,7 +553,6 @@ class HeterodynedTransientLikelihoodFD(TransientLikelihoodFD):
         prior: Prior,
         likelihood_transforms: list[NtoMTransform],
         sample_transforms: list[BijectiveTransform],
-        parameters_to_keep: list[str],
         popsize: int = 100,
         n_steps: int = 2000,
     ):
@@ -567,13 +564,8 @@ class HeterodynedTransientLikelihoodFD(TransientLikelihoodFD):
             named_params = dict(zip(parameter_names, x))
             for transform in reversed(sample_transforms):
                 named_params = transform.backward(named_params)
-            named_params_copy = named_params.copy()
             for transform in likelihood_transforms:
                 named_params = transform.forward(named_params)
-            jax.tree.map(
-                lambda key: named_params.update({key: named_params_copy[key]}),
-                parameters_to_keep,
-            )
             return -self.evaluate_original(named_params, {})
 
         print("Starting the optimizer")
@@ -604,13 +596,8 @@ class HeterodynedTransientLikelihoodFD(TransientLikelihoodFD):
         named_params = dict(zip(parameter_names, best_fit))
         for transform in reversed(sample_transforms):
             named_params = transform.backward(named_params)
-        named_params_copy = named_params.copy()
         for transform in likelihood_transforms:
             named_params = transform.forward(named_params)
-        jax.tree.map(
-            lambda key: named_params.update({key: named_params_copy[key]}),
-            parameters_to_keep,
-        )
         return named_params
 
 

--- a/src/jimgw/transforms.py
+++ b/src/jimgw/transforms.py
@@ -49,10 +49,6 @@ class NtoMTransform(Transform):
         x_copy = x.copy()
         output_params = self.transform_func(x_copy)
         jax.tree.map(
-            lambda key: x_copy.pop(key),
-            self.name_mapping[0],
-        )
-        jax.tree.map(
             lambda key: x_copy.update({key: output_params[key]}),
             list(output_params.keys()),
         )
@@ -89,7 +85,9 @@ class NtoNTransform(NtoMTransform):
         output_params = self.transform_func(transform_params)
         jacobian = jax.jacfwd(self.transform_func)(transform_params)
         jacobian = jnp.array(jax.tree.leaves(jacobian))
-        jacobian = jnp.log(jnp.absolute(jnp.linalg.det(jacobian.reshape(self.n_dim, self.n_dim))))
+        jacobian = jnp.log(
+            jnp.absolute(jnp.linalg.det(jacobian.reshape(self.n_dim, self.n_dim)))
+        )
         jax.tree.map(
             lambda key: x_copy.pop(key),
             self.name_mapping[0],
@@ -126,7 +124,9 @@ class BijectiveTransform(NtoNTransform):
         output_params = self.inverse_transform_func(transform_params)
         jacobian = jax.jacfwd(self.inverse_transform_func)(transform_params)
         jacobian = jnp.array(jax.tree.leaves(jacobian))
-        jacobian = jnp.log(jnp.absolute(jnp.linalg.det(jacobian.reshape(self.n_dim, self.n_dim))))
+        jacobian = jnp.log(
+            jnp.absolute(jnp.linalg.det(jacobian.reshape(self.n_dim, self.n_dim)))
+        )
         jax.tree.map(
             lambda key: y_copy.pop(key),
             self.name_mapping[1],


### PR DESCRIPTION
In this PR, the parameter `parameters_to_keep` is added to `Jim` and the `HeterodynedTransientLikelihoodFD` so that the parameters can be kept after the likelihood transform rather than having all of them dropped.

In the current approach, only the parameters after all the sampling inverse transforms, i.e., going back from $\vec{z}$ to $\vec{\theta}_{\rm prior}$, and before all likelihood transforms. We can further discuss whether that is the best placement for such treatment.