### PR TITLE
Adding Gaussian prior back

### DIFF
--- a/src/jimgw/prior.py
+++ b/src/jimgw/prior.py
@@ -4,7 +4,7 @@ import jax
 import jax.numpy as jnp
 from beartype import beartype as typechecker
 from flowMC.nfmodel.base import Distribution
-from jaxtyping import Array, Float, PRNGKeyArray, jaxtyped
+from jaxtyping import Array, Float, PRNGKeyArray, Bool, jaxtyped
 
 from jimgw.transforms import (
     BijectiveTransform,
@@ -277,8 +277,8 @@ class UniformPrior(SequentialTransformPrior):
 
 @jaxtyped(typechecker=typechecker)
 class GaussianPrior(SequentialTransformPrior):
-    mu: float
-    sigma: float
+    mu: float = 0.0
+    sigma: float = 1.0
 
     def __repr__(self):
         return f"GaussianPrior(mu={self.mu}, sigma={self.sigma}, parameter_names={self.parameter_names})"
@@ -298,7 +298,7 @@ class GaussianPrior(SequentialTransformPrior):
             [
                 ScaleTransform(
                     (
-                        [f"({self.parameter_names[0]}-({mu}))/{sigma}"],
+                        [f"{self.parameter_names[0]}_base"],
                         [f"{self.parameter_names[0]}-({mu})"],
                     ),
                     sigma,

--- a/src/jimgw/prior.py
+++ b/src/jimgw/prior.py
@@ -276,6 +276,42 @@ class UniformPrior(SequentialTransformPrior):
 
 
 @jaxtyped(typechecker=typechecker)
+class GaussianPrior(SequentialTransformPrior):
+    mu: float
+    sigma: float
+
+    def __repr__(self):
+        return f"GaussianPrior(mu={self.mu}, sigma={self.sigma}, parameter_names={self.parameter_names})"
+
+    def __init__(
+        self,
+        mu: float,
+        sigma: float,
+        parameter_names: list[str],
+    ):
+        self.parameter_names = parameter_names
+        assert self.n_dim == 1, "GaussianPrior needs to be 1D distributions"
+        self.mu = mu
+        self.sigma = sigma
+        super().__init__(
+            StandardNormalDistribution([f"{self.parameter_names[0]}_base"]),
+            [
+                ScaleTransform(
+                    (
+                        [f"({self.parameter_names[0]}-({mu}))/{sigma}"],
+                        [f"{self.parameter_names[0]}-({mu})"],
+                    ),
+                    sigma,
+                ),
+                OffsetTransform(
+                    ([f"{self.parameter_names[0]}-({mu})"], self.parameter_names),
+                    mu,
+                ),
+            ],
+        )
+
+
+@jaxtyped(typechecker=typechecker)
 class SinePrior(SequentialTransformPrior):
     """
     A prior distribution where the pdf is proportional to sin(x) in the range [0, pi].

--- a/src/jimgw/prior.py
+++ b/src/jimgw/prior.py
@@ -4,7 +4,7 @@ import jax
 import jax.numpy as jnp
 from beartype import beartype as typechecker
 from flowMC.nfmodel.base import Distribution
-from jaxtyping import Array, Float, PRNGKeyArray, Bool, jaxtyped
+from jaxtyping import Array, Float, PRNGKeyArray, jaxtyped
 
 from jimgw.transforms import (
     BijectiveTransform,

--- a/src/jimgw/prior.py
+++ b/src/jimgw/prior.py
@@ -277,18 +277,27 @@ class UniformPrior(SequentialTransformPrior):
 
 @jaxtyped(typechecker=typechecker)
 class GaussianPrior(SequentialTransformPrior):
-    mu: float = 0.0
-    sigma: float = 1.0
+    mu: Float = 0.0
+    sigma: Float = 1.0
 
     def __repr__(self):
         return f"GaussianPrior(mu={self.mu}, sigma={self.sigma}, parameter_names={self.parameter_names})"
 
     def __init__(
         self,
-        mu: float,
-        sigma: float,
+        mu: Float,
+        sigma: Float,
         parameter_names: list[str],
     ):
+        """
+        A convenient wrapper distribution on top of the StandardNormalDistribution class
+        which scale and translate the distribution according to the mean and standard deviation.
+
+        Args
+            mu: The mean of the distribution.
+            sigma: The standard deviation of the distribution.
+            parameter_names: A list of names for the parameters of the prior.
+        """
         self.parameter_names = parameter_names
         assert self.n_dim == 1, "GaussianPrior needs to be 1D distributions"
         self.mu = mu


### PR DESCRIPTION
The following commit uses the new jim's transform functionality to create a generic Gaussian distribution based on the currently available standard normal distribution.

If otherwise, replacing the standard one with a generic one (i.e., no transformations) is preferred. I am all good with that.

The following figure showcases the implementation is performing as expected. The mean is marked with the black dashed line, and the sigma is marked with an error bar at the expected height.

![test_jim_gaussian](https://github.com/user-attachments/assets/a8cb0e0c-8d2d-494b-bd71-4237ef03daf5)