### PR TITLE
Update names and values in constants.py

### DIFF
--- a/src/jimgw/constants.py
+++ b/src/jimgw/constants.py
@@ -3,7 +3,7 @@ import astropy.units as u  # type: ignore
 
 Msun = 4.9255e-6
 year = (1 * u.yr).cgs.value  # type: ignore
-Mpc = 1e6 * pc.value / c.value
+Mpc = 1e6 * pc.value  # m
 euler_gamma = 0.577215664901532860606512090082
 MR_sun = 1.476625061404649406193430731479084713e3
 C_SI = 299792458.0

--- a/src/jimgw/constants.py
+++ b/src/jimgw/constants.py
@@ -1,12 +1,21 @@
-from astropy.constants import c, pc  # type: ignore TODO: fix astropy stubs
+from astropy.constants import pc  # type: ignore TODO: fix astropy stubs
 import astropy.units as u  # type: ignore
 
-Msun = 4.9255e-6
+C_SI = 299792458.0
+""" Speed of light, m/s """
+
+MSUN  = 1.988409870698050731911960804878414216e30
+""" Nominal solar mass, kg """
+
+MTSUN = 4.925490947641266978197229498498379006e-6
+""" Geometrised Nominal solar mass, s """
+
+MRSUN = 1.476625061404649406193430731479084713e3
+""" Geometrised Nominal solar mass, m """
+
 year = (1 * u.yr).cgs.value  # type: ignore
 Mpc = 1e6 * pc.value  # m
 euler_gamma = 0.577215664901532860606512090082
-MR_sun = 1.476625061404649406193430731479084713e3
-C_SI = 299792458.0
 
 EARTH_SEMI_MAJOR_AXIS = 6378137.0  # for ellipsoid model of Earth, in m
 EARTH_SEMI_MINOR_AXIS = 6356752.314  # in m

--- a/src/jimgw/single_event/utils.py
+++ b/src/jimgw/single_event/utils.py
@@ -2,7 +2,7 @@ import jax.numpy as jnp
 from jax.scipy.integrate import trapezoid
 from jaxtyping import Array, Float
 
-from jimgw.constants import Msun
+from jimgw.constants import MTSUN
 
 
 def inner_product(
@@ -499,7 +499,7 @@ def spin_to_cartesian_spin(
 
     m1, m2 = Mc_q_to_m1_m2(M_c, q)
     eta = q / (1 + q) ** 2
-    v0 = jnp.cbrt((m1 + m2) * Msun * jnp.pi * fRef)
+    v0 = jnp.cbrt((m1 + m2) * MTSUN * jnp.pi * fRef)
 
     Lmag = ((m1 + m2) * (m1 + m2) * eta / v0) * (1.0 + v0 * v0 * (1.5 + eta / 6.0))
     s1 = m1 * m1 * chi1 * s1hat


### PR DESCRIPTION
This PR updates the value of `Mpc` by removing the division by the speed of light, and also updates the names of some constants to conform with Ripple.

Only one of the affected constants is used in `utils.py`, and has been updated as well. 