### PR TITLE
Pass conditional_names in reverse_bijective_transform

### DIFF
--- a/src/jimgw/transforms.py
+++ b/src/jimgw/transforms.py
@@ -530,11 +530,13 @@ def reverse_bijective_transform(
         original_transform.name_mapping[1],
         original_transform.name_mapping[0],
     )
-    reversed_transform = BijectiveTransform(name_mapping=reversed_name_mapping)
+    if isinstance(original_transform, ConditionalBijectiveTransform):
+        reversed_transform = ConditionalBijectiveTransform(name_mapping=reversed_name_mapping)
+        reversed_transform.conditional_names = original_transform.conditional_names
+    else:
+        reversed_transform = BijectiveTransform(name_mapping=reversed_name_mapping)
     reversed_transform.transform_func = original_transform.inverse_transform_func
     reversed_transform.inverse_transform_func = original_transform.transform_func
     reversed_transform.__repr__ = lambda: f"Reversed{repr(original_transform)}"
-    if isinstance(original_transform, ConditionalBijectiveTransform):
-        reversed_transform.conditional_names = original_transform.conditional_names
 
     return reversed_transform

--- a/src/jimgw/transforms.py
+++ b/src/jimgw/transforms.py
@@ -531,8 +531,10 @@ def reverse_bijective_transform(
         original_transform.name_mapping[0],
     )
     if isinstance(original_transform, ConditionalBijectiveTransform):
-        reversed_transform = ConditionalBijectiveTransform(name_mapping=reversed_name_mapping)
-        reversed_transform.conditional_names = original_transform.conditional_names
+        reversed_transform = ConditionalBijectiveTransform(
+            name_mapping=reversed_name_mapping,
+            conditional_names=original_transform.conditional_names,
+        )
     else:
         reversed_transform = BijectiveTransform(name_mapping=reversed_name_mapping)
     reversed_transform.transform_func = original_transform.inverse_transform_func

--- a/src/jimgw/transforms.py
+++ b/src/jimgw/transforms.py
@@ -534,5 +534,7 @@ def reverse_bijective_transform(
     reversed_transform.transform_func = original_transform.inverse_transform_func
     reversed_transform.inverse_transform_func = original_transform.transform_func
     reversed_transform.__repr__ = lambda: f"Reversed{repr(original_transform)}"
+    if isinstance(original_transform, ConditionalBijectiveTransform):
+        reversed_transform.conditional_names = original_transform.conditional_names
 
     return reversed_transform


### PR DESCRIPTION
The `reverse_bijective_transform` function doesn't work for `ConditionalBijectiveTransform` now. This PR fixed this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the reversal process for transformations to correctly handle conditional behavior, ensuring that all necessary attributes are accurately preserved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->