### PR TITLE
Updated PSD loading method

### DIFF
--- a/src/jimgw/single_event/detector.py
+++ b/src/jimgw/single_event/detector.py
@@ -202,6 +202,7 @@ class GroundBased2G(Detector):
         f_min: Float,
         f_max: Float,
         psd_pad: int = 16,
+        psd_duration: int = 16,
         tukey_alpha: Float = 0.2,
         gwpy_kwargs: dict = {"cache": True},
     ) -> None:
@@ -222,6 +223,8 @@ class GroundBased2G(Detector):
             The maximum frequency to fetch data.
         psd_pad : int
             The amount of time to pad the PSD data.
+        psd_duration : int
+            The duration of the PSD data.
         tukey_alpha : Float
             The alpha parameter for the Tukey window.
 
@@ -241,7 +244,7 @@ class GroundBased2G(Detector):
         data = jnp.fft.rfft(jnp.array(data_td.value) * tukey(n, tukey_alpha)) * delta_t
         freq = jnp.fft.rfftfreq(n, delta_t)
         # TODO: Check if this is the right way to fetch PSD
-        start_psd = int(trigger_time) - gps_start_pad - 2 * psd_pad
+        start_psd = int(trigger_time) - gps_start_pad - psd_pad - psd_duration
         end_psd = int(trigger_time) - gps_start_pad - psd_pad
 
         print("Fetching PSD data...")


### PR DESCRIPTION
I believe this is a more correct method of loading the open data from GWOSC. Currently, the psd data is loaded from the times:
```
start_psd = int(trigger_time) - gps_start_pad - 2 * psd_pad
end_psd = int(trigger_time) - gps_start_pad - psd_pad
```

However this seems to conflate the ```psd_duration``` with the ```psd_pad``` time. For example, with GW170817, the BNS has a duration of ~100s, and we would like to take ~100-1000s of PSD data. With the current implementation, this would result in the ```end_psd``` time being ~100-1000s before the signal start time. This results in wildly inaccurate posteriors as the background noise is essentially calibrated incorrectly.

By defining a new parameter, ```psd_duration```, you would be able to accurately define the PSD data segment:
```start_psd = int(trigger_time) - gps_start_pad - psd_pad - psd_duration```

I've amended it such that it retains the same original functionality, i.e. ```psd_duration: int = 16```, so it shouldn't impact the existing base functionality.

I would also like to implement a ```load_data_from_file``` function in the future, as it should be relatively straightforward to hookup to the current pipeline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a configurable duration option for PSD data retrieval, giving users improved control over the range and timing of the fetched data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->