### PR TITLE
fix longitude of V1

### DIFF
--- a/src/jimgw/single_event/detector.py
+++ b/src/jimgw/single_event/detector.py
@@ -461,7 +461,7 @@ L1 = GroundBased2G(
 V1 = GroundBased2G(
     "V1",
     latitude=(43 + 37.0 / 60 + 53.0921 / 3600) * DEG_TO_RAD,
-    longitude=(10 + 30.0 / 60 + 16.1887 / 3600) * DEG_TO_RAD,
+    longitude=(10 + 30.0 / 60 + 16.1878 / 3600) * DEG_TO_RAD,
     xarm_azimuth=70.5674 * DEG_TO_RAD,
     yarm_azimuth=160.5674 * DEG_TO_RAD,
     xarm_tilt=0,


### PR DESCRIPTION
There is a minor change in the `longitude` of `V1`
See: [bilby's detector settings](https://git.ligo.org/lscsoft/bilby/-/blob/master/bilby/gw/detector/detectors/V1.interferometer)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Adjusted the detector's geographical positioning for improved location accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->