### PR TITLE
Remove `post_trigger_duration` from likelihood initialisation

### DIFF
--- a/example/GW150914_IMRPhenomD.py
+++ b/example/GW150914_IMRPhenomD.py
@@ -145,7 +145,6 @@ likelihood = TransientLikelihoodFD(
     trigger_time=gps,
     f_min=fmin,
     f_max=fmax,
-    start_time=start,
 )
 
 

--- a/example/GW150914_IMRPhenomD.py
+++ b/example/GW150914_IMRPhenomD.py
@@ -121,59 +121,19 @@ prior = CombinePrior(prior)
 # Defining Transforms
 
 sample_transforms = [
-    DistanceToSNRWeightedDistanceTransform(
-        gps_time=gps, ifos=ifos, dL_min=dL_prior.xmin, dL_max=dL_prior.xmax
-    ),
+    DistanceToSNRWeightedDistanceTransform(gps_time=gps, ifos=ifos, dL_min=dL_prior.xmin, dL_max=dL_prior.xmax),
     GeocentricArrivalPhaseToDetectorArrivalPhaseTransform(gps_time=gps, ifo=ifos[0]),
-    GeocentricArrivalTimeToDetectorArrivalTimeTransform(
-        tc_min=t_c_prior.xmin, tc_max=t_c_prior.xmax, gps_time=gps, ifo=ifos[0]
-    ),
+    GeocentricArrivalTimeToDetectorArrivalTimeTransform(tc_min=t_c_prior.xmin, tc_max=t_c_prior.xmax, gps_time=gps, ifo=ifos[0]),
     SkyFrameToDetectorFrameSkyPositionTransform(gps_time=gps, ifos=ifos),
-    BoundToUnbound(
-        name_mapping=(["M_c"], ["M_c_unbounded"]),
-        original_lower_bound=M_c_min,
-        original_upper_bound=M_c_max,
-    ),
-    BoundToUnbound(
-        name_mapping=(["q"], ["q_unbounded"]),
-        original_lower_bound=q_min,
-        original_upper_bound=q_max,
-    ),
-    BoundToUnbound(
-        name_mapping=(["s1_z"], ["s1_z_unbounded"]),
-        original_lower_bound=-1.0,
-        original_upper_bound=1.0,
-    ),
-    BoundToUnbound(
-        name_mapping=(["s2_z"], ["s2_z_unbounded"]),
-        original_lower_bound=-1.0,
-        original_upper_bound=1.0,
-    ),
-    BoundToUnbound(
-        name_mapping=(["iota"], ["iota_unbounded"]),
-        original_lower_bound=0.0,
-        original_upper_bound=jnp.pi,
-    ),
-    BoundToUnbound(
-        name_mapping=(["phase_det"], ["phase_det_unbounded"]),
-        original_lower_bound=0.0,
-        original_upper_bound=2 * jnp.pi,
-    ),
-    BoundToUnbound(
-        name_mapping=(["psi"], ["psi_unbounded"]),
-        original_lower_bound=0.0,
-        original_upper_bound=jnp.pi,
-    ),
-    BoundToUnbound(
-        name_mapping=(["zenith"], ["zenith_unbounded"]),
-        original_lower_bound=0.0,
-        original_upper_bound=jnp.pi,
-    ),
-    BoundToUnbound(
-        name_mapping=(["azimuth"], ["azimuth_unbounded"]),
-        original_lower_bound=0.0,
-        original_upper_bound=2 * jnp.pi,
-    ),
+    BoundToUnbound(name_mapping=(["M_c"], ["M_c_unbounded"]), original_lower_bound=M_c_min, original_upper_bound=M_c_max,),
+    BoundToUnbound(name_mapping=(["q"], ["q_unbounded"]), original_lower_bound=q_min, original_upper_bound=q_max,),
+    BoundToUnbound(name_mapping=(["s1_z"], ["s1_z_unbounded"]), original_lower_bound=-1.0, original_upper_bound=1.0,),
+    BoundToUnbound(name_mapping=(["s2_z"], ["s2_z_unbounded"]), original_lower_bound=-1.0, original_upper_bound=1.0,),
+    BoundToUnbound(name_mapping=(["iota"], ["iota_unbounded"]), original_lower_bound=0.0, original_upper_bound=jnp.pi,),
+    BoundToUnbound(name_mapping=(["phase_det"], ["phase_det_unbounded"]), original_lower_bound=0.0, original_upper_bound=2 * jnp.pi,),
+    BoundToUnbound(name_mapping=(["psi"], ["psi_unbounded"]), original_lower_bound=0.0, original_upper_bound=jnp.pi,),
+    BoundToUnbound(name_mapping=(["zenith"], ["zenith_unbounded"]), original_lower_bound=0.0, original_upper_bound=jnp.pi,),
+    BoundToUnbound(name_mapping=(["azimuth"], ["azimuth_unbounded"]), original_lower_bound=0.0, original_upper_bound=2 * jnp.pi,),
 ]
 
 likelihood_transforms = [
@@ -182,8 +142,12 @@ likelihood_transforms = [
 
 
 likelihood = TransientLikelihoodFD(
-    [H1, L1], waveform=waveform, trigger_time=gps, f_min=fmin,
-    f_max=fmax, post_trigger_duration=2,
+    [H1, L1],
+    waveform=waveform,
+    trigger_time=gps,
+    f_min=fmin,
+    f_max=fmax,
+    start_time=start,
 )
 
 
@@ -199,26 +163,26 @@ jim = Jim(
     sample_transforms=sample_transforms,
     likelihood_transforms=likelihood_transforms,
     rng_key=jax.random.PRNGKey(42),
-    n_chains = 500,
-    n_local_steps = 20,
-    n_global_steps = 5,
-    n_training_loops = 200,
-    n_production_loops = 100,
-    n_epochs = 20,
-    mala_step_size = mass_matrix * 1e-3,
-    rq_spline_hidden_units = [128, 128],
-    rq_spline_n_bins = 10,
-    rq_spline_n_layers = 8,
-    learning_rate = 1e-3,
-    batch_size = 10000,
-    n_max_examples = 10000,
-    n_NFproposal_batch_size = 5,
+    n_chains=500,
+    n_local_steps=20,
+    n_global_steps=5,
+    n_training_loops=200,
+    n_production_loops=100,
+    n_epochs=20,
+    mala_step_size=mass_matrix * 1e-3,
+    rq_spline_hidden_units=[128, 128],
+    rq_spline_n_bins=10,
+    rq_spline_n_layers=8,
+    learning_rate=1e-3,
+    batch_size=10000,
+    n_max_examples=10000,
+    n_NFproposal_batch_size=5,
     local_thinning=1,
     global_thinning=1,
-    history_window = 200,
-    n_temperatures = 10,
-    max_temperature = 20.0,
-    n_tempered_steps = 10,
+    history_window=200,
+    n_temperatures=10,
+    max_temperature=20.0,
+    n_tempered_steps=10,
     verbose=True,
 )
 

--- a/example/GW150914_IMRPhenomD.py
+++ b/example/GW150914_IMRPhenomD.py
@@ -2,6 +2,7 @@ import time
 
 import jax
 import jax.numpy as jnp
+jax.config.update("jax_enable_x64", True)
 
 from jimgw.jim import Jim
 from jimgw.prior import (
@@ -11,6 +12,7 @@ from jimgw.prior import (
     SinePrior,
     PowerLawPrior,
 )
+from jimgw.single_event.data import Data
 from jimgw.single_event.detector import H1, L1
 from jimgw.single_event.likelihood import TransientLikelihoodFD
 from jimgw.single_event.waveform import RippleIMRPhenomD
@@ -22,10 +24,6 @@ from jimgw.single_event.transforms import (
     GeocentricArrivalTimeToDetectorArrivalTimeTransform,
     GeocentricArrivalPhaseToDetectorArrivalPhaseTransform,
 )
-from jimgw.single_event import data as jd
-
-
-jax.config.update("jax_enable_x64", True)
 
 ###########################################
 ########## First we grab data #############
@@ -58,11 +56,11 @@ ifos = [H1, L1]
 
 for ifo in ifos:
     # set analysis data
-    data = jd.Data.from_gwosc(ifo.name, start, end)
+    data = Data.from_gwosc(ifo.name, start, end)
     ifo.set_data(data)
 
     # set PSD (Welch estimate)
-    psd_data = jd.Data.from_gwosc(ifo.name, psd_start, psd_end)
+    psd_data = Data.from_gwosc(ifo.name, psd_start, psd_end)
     # set an NFFT corresponding to the analysis segment duration
     psd_fftlength = data.duration * data.sampling_frequency
     ifo.set_psd(psd_data.to_psd(nperseg=psd_fftlength))

--- a/example/GW150914_IMRPhenomPV2.py
+++ b/example/GW150914_IMRPhenomPV2.py
@@ -154,7 +154,6 @@ likelihood = TransientLikelihoodFD(
     trigger_time=gps,
     f_min=fmin,
     f_max=fmax,
-    start_time=start,
 )
 
 mass_matrix = jnp.eye(prior.n_dim)

--- a/example/GW150914_IMRPhenomPV2.py
+++ b/example/GW150914_IMRPhenomPV2.py
@@ -14,6 +14,7 @@ from jimgw.prior import (
 )
 from jimgw.single_event.detector import H1, L1
 from jimgw.single_event.likelihood import TransientLikelihoodFD
+from jimgw.single_event.data import Data
 from jimgw.single_event.waveform import RippleIMRPhenomPv2
 from jimgw.transforms import BoundToUnbound
 from jimgw.single_event.transforms import (
@@ -24,7 +25,6 @@ from jimgw.single_event.transforms import (
     GeocentricArrivalTimeToDetectorArrivalTimeTransform,
     GeocentricArrivalPhaseToDetectorArrivalPhaseTransform,
 )
-from jimgw.single_event import data as jd
 
 jax.config.update("jax_enable_x64", True)
 
@@ -59,11 +59,11 @@ ifos = [H1, L1]
 
 for ifo in ifos:
     # set analysis data
-    data = jd.Data.from_gwosc(ifo.name, start, end)
+    data = Data.from_gwosc(ifo.name, start, end)
     ifo.set_data(data)
 
     # set PSD (Welch estimate)
-    psd_data = jd.Data.from_gwosc(ifo.name, psd_start, psd_end)
+    psd_data = Data.from_gwosc(ifo.name, psd_start, psd_end)
     # set an NFFT corresponding to the analysis segment duration
     psd_fftlength = data.duration * data.sampling_frequency
     ifo.set_psd(psd_data.to_psd(nperseg=psd_fftlength))
@@ -126,19 +126,19 @@ sample_transforms = [
     GeocentricArrivalPhaseToDetectorArrivalPhaseTransform(gps_time=gps, ifo=ifos[0]),
     GeocentricArrivalTimeToDetectorArrivalTimeTransform(tc_min=t_c_prior.xmin, tc_max=t_c_prior.xmax, gps_time=gps, ifo=ifos[0]),
     SkyFrameToDetectorFrameSkyPositionTransform(gps_time=gps, ifos=ifos),
-    BoundToUnbound(name_mapping = (["M_c"], ["M_c_unbounded"]), original_lower_bound=M_c_min, original_upper_bound=M_c_max),
-    BoundToUnbound(name_mapping = (["q"], ["q_unbounded"]), original_lower_bound=q_min, original_upper_bound=q_max),
-    BoundToUnbound(name_mapping = (["s1_phi"], ["s1_phi_unbounded"]) , original_lower_bound=0.0, original_upper_bound=2 * jnp.pi),
-    BoundToUnbound(name_mapping = (["s2_phi"], ["s2_phi_unbounded"]) , original_lower_bound=0.0, original_upper_bound=2 * jnp.pi),
-    BoundToUnbound(name_mapping = (["iota"], ["iota_unbounded"]) , original_lower_bound=0.0, original_upper_bound=jnp.pi),
-    BoundToUnbound(name_mapping = (["s1_theta"], ["s1_theta_unbounded"]) , original_lower_bound=0.0, original_upper_bound=jnp.pi),
-    BoundToUnbound(name_mapping = (["s2_theta"], ["s2_theta_unbounded"]) , original_lower_bound=0.0, original_upper_bound=jnp.pi),
-    BoundToUnbound(name_mapping = (["s1_mag"], ["s1_mag_unbounded"]) , original_lower_bound=0.0, original_upper_bound=0.99),
-    BoundToUnbound(name_mapping = (["s2_mag"], ["s2_mag_unbounded"]) , original_lower_bound=0.0, original_upper_bound=0.99),
-    BoundToUnbound(name_mapping = (["phase_det"], ["phase_det_unbounded"]), original_lower_bound=0.0, original_upper_bound=2 * jnp.pi),
-    BoundToUnbound(name_mapping = (["psi"], ["psi_unbounded"]), original_lower_bound=0.0, original_upper_bound=jnp.pi),
-    BoundToUnbound(name_mapping = (["zenith"], ["zenith_unbounded"]), original_lower_bound=0.0, original_upper_bound=jnp.pi),
-    BoundToUnbound(name_mapping = (["azimuth"], ["azimuth_unbounded"]), original_lower_bound=0.0, original_upper_bound=2 * jnp.pi),
+    BoundToUnbound(name_mapping=(["M_c"], ["M_c_unbounded"]), original_lower_bound=M_c_min, original_upper_bound=M_c_max,),
+    BoundToUnbound(name_mapping=(["q"], ["q_unbounded"]), original_lower_bound=q_min, original_upper_bound=q_max,),
+    BoundToUnbound(name_mapping=(["s1_phi"], ["s1_phi_unbounded"]), original_lower_bound=0.0, original_upper_bound=2 * jnp.pi,),
+    BoundToUnbound(name_mapping=(["s2_phi"], ["s2_phi_unbounded"]), original_lower_bound=0.0, original_upper_bound=2 * jnp.pi,),
+    BoundToUnbound(name_mapping=(["iota"], ["iota_unbounded"]), original_lower_bound=0.0, original_upper_bound=jnp.pi,),
+    BoundToUnbound(name_mapping=(["s1_theta"], ["s1_theta_unbounded"]), original_lower_bound=0.0, original_upper_bound=jnp.pi,),
+    BoundToUnbound(name_mapping=(["s2_theta"], ["s2_theta_unbounded"]), original_lower_bound=0.0, original_upper_bound=jnp.pi,),
+    BoundToUnbound(name_mapping=(["s1_mag"], ["s1_mag_unbounded"]), original_lower_bound=0.0, original_upper_bound=0.99,),
+    BoundToUnbound(name_mapping=(["s2_mag"], ["s2_mag_unbounded"]), original_lower_bound=0.0, original_upper_bound=0.99,),
+    BoundToUnbound(name_mapping=(["phase_det"], ["phase_det_unbounded"]), original_lower_bound=0.0, original_upper_bound=2 * jnp.pi,),
+    BoundToUnbound(name_mapping=(["psi"], ["psi_unbounded"]), original_lower_bound=0.0, original_upper_bound=jnp.pi,),
+    BoundToUnbound(name_mapping=(["zenith"], ["zenith_unbounded"]), original_lower_bound=0.0, original_upper_bound=jnp.pi,),
+    BoundToUnbound(name_mapping=(["azimuth"], ["azimuth_unbounded"]), original_lower_bound=0.0, original_upper_bound=2 * jnp.pi,),
 ]
 
 likelihood_transforms = [
@@ -149,8 +149,12 @@ likelihood_transforms = [
 
 
 likelihood = TransientLikelihoodFD(
-    [H1, L1], waveform=waveform, trigger_time=gps, f_min=fmin,
-    f_max=fmax, post_trigger_duration=2,
+    [H1, L1],
+    waveform=waveform,
+    trigger_time=gps,
+    f_min=fmin,
+    f_max=fmax,
+    start_time=start,
 )
 
 mass_matrix = jnp.eye(prior.n_dim)
@@ -164,35 +168,34 @@ jim = Jim(
     prior,
     sample_transforms=sample_transforms,
     likelihood_transforms=likelihood_transforms,
-    n_chains = 500,
-    n_local_steps = 20,
-    n_global_steps = 5,
-    n_training_loops = 200,
-    n_production_loops = 100,
-    n_epochs = 20,
-    mala_step_size = mass_matrix * 2e-3,
-    rq_spline_hidden_units = [128, 128],
-    rq_spline_n_bins = 10,
-    rq_spline_n_layers = 8,
-    learning_rate = 1e-3,
-    batch_size = 10000,
-    n_max_examples = 10000,
-    n_NFproposal_batch_size = 5,
+    n_chains=500,
+    n_local_steps=20,
+    n_global_steps=5,
+    n_training_loops=200,
+    n_production_loops=100,
+    n_epochs=20,
+    mala_step_size=mass_matrix * 2e-3,
+    rq_spline_hidden_units=[128, 128],
+    rq_spline_n_bins=10,
+    rq_spline_n_layers=8,
+    learning_rate=1e-3,
+    batch_size=10000,
+    n_max_examples=10000,
+    n_NFproposal_batch_size=5,
     local_thinning=1,
     global_thinning=1,
-    history_window = 200,
-    n_temperatures = 10,
-    max_temperature = 20.0,
-    n_tempered_steps = 10,
+    history_window=200,
+    n_temperatures=10,
+    max_temperature=20.0,
+    n_tempered_steps=10,
     verbose=True,
 )
-# 
+#
 jim.sample(jax.random.PRNGKey(42))
 
 print("Done!")
 
-logprob = jim.sampler.resources['log_prob_production'].data
+logprob = jim.sampler.resources["log_prob_production"].data
 print(jnp.mean(logprob))
 
 jim.get_samples()
-

--- a/example/GW170817_IMRPhenomD.py
+++ b/example/GW170817_IMRPhenomD.py
@@ -145,7 +145,6 @@ likelihood = HeterodynedTransientLikelihoodFD(
     waveform=waveform,
     n_bins=1000,
     trigger_time=gps,
-    start_time=start,
     prior=prior,
     sample_transforms=sample_transforms,
     likelihood_transforms=likelihood_transforms,

--- a/example/GW170817_IMRPhenomD.py
+++ b/example/GW170817_IMRPhenomD.py
@@ -3,7 +3,8 @@ import time
 import jax
 import jax.numpy as jnp
 
-from jimgw.jim import Jim
+jax.config.update("jax_enable_x64", True)
+
 from jimgw.jim import Jim
 from jimgw.prior import (
     CombinePrior,
@@ -11,24 +12,20 @@ from jimgw.prior import (
     CosinePrior,
     SinePrior,
     PowerLawPrior,
-    UniformSpherePrior,
 )
 from jimgw.single_event.detector import H1, L1, V1
-from jimgw.single_event.likelihood import TransientLikelihoodFD, HeterodynedTransientLikelihoodFD
+from jimgw.single_event.likelihood import HeterodynedTransientLikelihoodFD
+from jimgw.single_event.data import Data
 from jimgw.single_event.waveform import RippleIMRPhenomD
 from jimgw.transforms import BoundToUnbound
 from jimgw.single_event.transforms import (
     SkyFrameToDetectorFrameSkyPositionTransform,
-    SphereSpinToCartesianSpinTransform,
     MassRatioToSymmetricMassRatioTransform,
     DistanceToSNRWeightedDistanceTransform,
     GeocentricArrivalTimeToDetectorArrivalTimeTransform,
     GeocentricArrivalPhaseToDetectorArrivalPhaseTransform,
 )
-from jimgw.single_event.utils import Mc_q_to_m1_m2
 from flowMC.strategy.optimization import optimization_Adam
-
-jax.config.update("jax_enable_x64", True)
 
 ###########################################
 ########## First we grab data #############
@@ -36,34 +33,43 @@ jax.config.update("jax_enable_x64", True)
 
 total_time_start = time.time()
 
-# first, fetch a 4s segment centered on GW150914
-
+# first, fetch a 128s segment centered on GW170817
+# for the analysis
 gps = 1187008882.43
-trigger_time = gps
-fmin = 20
-fmax = 2048
-minimum_frequency = fmin
-maximum_frequency = fmax
-duration = 128
-post_trigger_duration = 2
-epoch = duration - post_trigger_duration
+duration = 128.0
+# Request a segment with 2.0 s post-merger
+start = gps + 2.0 - duration
+end = start + duration
+
+# fetch 8192s of data to estimate the PSD (to be
+# careful we should avoid the on-source segment,
+# but we don't do this in this example)
+psd_start = gps - 4096
+psd_end = gps + 4096
+
+fmin = minimum_frequency = 20
+fmax = maximum_frequency = 2048
 f_ref = fmin
 
+# initialize detectors
 ifos = [H1, L1, V1]
 
+for ifo in ifos:
+    # set analysis data
+    strain_data = Data.from_gwosc(ifo.name, start, end)
+    ifo.set_data(strain_data)
 
-tukey_alpha = 2 / (duration / 2)
-H1.load_data(
-    gps, duration, 2, fmin, fmax, psd_pad=duration + 16, tukey_alpha=tukey_alpha
-)
-L1.load_data(
-    gps, duration, 2, fmin, fmax, psd_pad=duration + 16, tukey_alpha=tukey_alpha
-)
-V1.load_data(
-    gps, duration, 2, fmin, fmax, psd_pad=duration + 16, tukey_alpha=tukey_alpha
-)
+    # set PSD (Welch estimate)
+    psd_data = Data.from_gwosc(ifo.name, psd_start, psd_end)
+    # set an NFFT corresponding to the analysis segment duration
+    psd_fftlength = strain_data.duration * strain_data.sampling_frequency
+    ifo.set_psd(psd_data.to_psd(nperseg=psd_fftlength))
 
+###########################################
+########## Set up waveform ################
+###########################################
 
+# initialize waveform
 waveform = RippleIMRPhenomD(f_ref=f_ref)
 
 ###########################################
@@ -81,6 +87,7 @@ q_prior = UniformPrior(q_min, q_max, parameter_names=["q"])
 prior = prior + [Mc_prior, q_prior]
 
 # Spin prior
+## Note that the Pv2 example limits the spin magnitude to be < 0.05.
 s1_prior = UniformPrior(-1.0, 1.0, parameter_names=["s1_z"])
 s2_prior = UniformPrior(-1.0, 1.0, parameter_names=["s2_z"])
 iota_prior = SinePrior(parameter_names=["iota"])
@@ -117,15 +124,15 @@ sample_transforms = [
     GeocentricArrivalPhaseToDetectorArrivalPhaseTransform(gps_time=gps, ifo=ifos[0]),
     GeocentricArrivalTimeToDetectorArrivalTimeTransform(tc_min=t_c_prior.xmin, tc_max=t_c_prior.xmax, gps_time=gps, ifo=ifos[0]),
     SkyFrameToDetectorFrameSkyPositionTransform(gps_time=gps, ifos=ifos),
-    BoundToUnbound(name_mapping = (["M_c"], ["M_c_unbounded"]), original_lower_bound=M_c_min, original_upper_bound=M_c_max),
-    BoundToUnbound(name_mapping = (["q"], ["q_unbounded"]), original_lower_bound=q_min, original_upper_bound=q_max),
-    BoundToUnbound(name_mapping = (["s1_z"], ["s1_z_unbounded"]) , original_lower_bound=-1.0, original_upper_bound=1.0),
-    BoundToUnbound(name_mapping = (["s2_z"], ["s2_z_unbounded"]) , original_lower_bound=-1.0, original_upper_bound=1.0),
-    BoundToUnbound(name_mapping = (["iota"], ["iota_unbounded"]) , original_lower_bound=0.0, original_upper_bound=jnp.pi),
-    BoundToUnbound(name_mapping = (["phase_det"], ["phase_det_unbounded"]), original_lower_bound=0.0, original_upper_bound=2 * jnp.pi),
-    BoundToUnbound(name_mapping = (["psi"], ["psi_unbounded"]), original_lower_bound=0.0, original_upper_bound=jnp.pi),
-    BoundToUnbound(name_mapping = (["zenith"], ["zenith_unbounded"]), original_lower_bound=0.0, original_upper_bound=jnp.pi),
-    BoundToUnbound(name_mapping = (["azimuth"], ["azimuth_unbounded"]), original_lower_bound=0.0, original_upper_bound=2 * jnp.pi),
+    BoundToUnbound(name_mapping=(["M_c"], ["M_c_unbounded"]), original_lower_bound=M_c_min, original_upper_bound=M_c_max,),
+    BoundToUnbound(name_mapping=(["q"], ["q_unbounded"]), original_lower_bound=q_min, original_upper_bound=q_max,),
+    BoundToUnbound(name_mapping=(["s1_z"], ["s1_z_unbounded"]), original_lower_bound=-1.0, original_upper_bound=1.0,),
+    BoundToUnbound(name_mapping=(["s2_z"], ["s2_z_unbounded"]), original_lower_bound=-1.0, original_upper_bound=1.0,),
+    BoundToUnbound(name_mapping=(["iota"], ["iota_unbounded"]), original_lower_bound=0.0, original_upper_bound=jnp.pi,),
+    BoundToUnbound(name_mapping=(["phase_det"], ["phase_det_unbounded"]), original_lower_bound=0.0, original_upper_bound=2 * jnp.pi,),
+    BoundToUnbound(name_mapping=(["psi"], ["psi_unbounded"]), original_lower_bound=0.0, original_upper_bound=jnp.pi,),
+    BoundToUnbound(name_mapping=(["zenith"], ["zenith_unbounded"]), original_lower_bound=0.0, original_upper_bound=jnp.pi,),
+    BoundToUnbound(name_mapping=(["azimuth"], ["azimuth_unbounded"]), original_lower_bound=0.0, original_upper_bound=2 * jnp.pi,),
 ]
 
 likelihood_transforms = [
@@ -133,16 +140,25 @@ likelihood_transforms = [
 ]
 
 
-#likelihood = TransientLikelihoodFD(
-#    [H1, L1, V1], waveform=waveform, trigger_time=trigger_time, duration=duration, post_trigger_duration=post_trigger_duration
-#)
-
-likelihood = HeterodynedTransientLikelihoodFD(ifos, waveform=waveform, n_bins = 1000, trigger_time=trigger_time, duration=duration, post_trigger_duration=post_trigger_duration, prior = prior, sample_transforms = sample_transforms, likelihood_transforms = likelihood_transforms, popsize = 10, n_steps = 50)
+likelihood = HeterodynedTransientLikelihoodFD(
+    ifos,
+    waveform=waveform,
+    n_bins=1000,
+    trigger_time=gps,
+    start_time=start,
+    prior=prior,
+    sample_transforms=sample_transforms,
+    likelihood_transforms=likelihood_transforms,
+    popsize=10,
+    n_steps=50,
+)
 
 mass_matrix = jnp.eye(prior.n_dim)
 # mass_matrix = mass_matrix.at[1, 1].set(1e-3)
 # mass_matrix = mass_matrix.at[9, 9].set(1e-3)
 local_sampler_arg = {"step_size": mass_matrix * 1e-3}
+
+#### The rest of this script is not guaranteed to work ####
 
 Adam_optimizer = optimization_Adam(n_steps=3000, learning_rate=0.01, noise_level=1)
 

--- a/example/GW170817_IMRPhenomPV2.py
+++ b/example/GW170817_IMRPhenomPV2.py
@@ -3,7 +3,8 @@ import time
 import jax
 import jax.numpy as jnp
 
-from jimgw.jim import Jim
+jax.config.update("jax_enable_x64", True)
+
 from jimgw.jim import Jim
 from jimgw.prior import (
     CombinePrior,
@@ -14,7 +15,8 @@ from jimgw.prior import (
     UniformSpherePrior,
 )
 from jimgw.single_event.detector import H1, L1, V1
-from jimgw.single_event.likelihood import TransientLikelihoodFD, HeterodynedTransientLikelihoodFD
+from jimgw.single_event.likelihood import HeterodynedTransientLikelihoodFD
+from jimgw.single_event.data import Data
 from jimgw.single_event.waveform import RippleIMRPhenomPv2
 from jimgw.transforms import BoundToUnbound
 from jimgw.single_event.transforms import (
@@ -25,10 +27,7 @@ from jimgw.single_event.transforms import (
     GeocentricArrivalTimeToDetectorArrivalTimeTransform,
     GeocentricArrivalPhaseToDetectorArrivalPhaseTransform,
 )
-from jimgw.single_event.utils import Mc_q_to_m1_m2
 from flowMC.strategy.optimization import optimization_Adam
-
-jax.config.update("jax_enable_x64", True)
 
 ###########################################
 ########## First we grab data #############
@@ -36,35 +35,44 @@ jax.config.update("jax_enable_x64", True)
 
 total_time_start = time.time()
 
-# first, fetch a 4s segment centered on GW150914
-
+# first, fetch a 128s segment centered on GW170817
+# for the analysis
 gps = 1187008882.43
-trigger_time = gps
-fmin = 20
-fmax = 2048
-minimum_frequency = fmin
-maximum_frequency = fmax
-duration = 128
-post_trigger_duration = 2
-epoch = duration - post_trigger_duration
+duration = 128.0
+# Request a segment with 2.0 s post-merger
+start = gps + 2.0 - duration
+end = start + duration
+
+# fetch 8192s of data to estimate the PSD (to be
+# careful we should avoid the on-source segment,
+# but we don't do this in this example)
+psd_start = gps - 4096
+psd_end = gps + 4096
+
+fmin = minimum_frequency = 20
+fmax = maximum_frequency = 2048
 f_ref = fmin
 
+# initialize detectors
 ifos = [H1, L1, V1]
 
+for ifo in ifos:
+    # set analysis data
+    strain_data = Data.from_gwosc(ifo.name, start, end)
+    ifo.set_data(strain_data)
 
-tukey_alpha = 2 / (duration / 2)
-H1.load_data(
-    gps, duration, 2, fmin, fmax, psd_pad=duration + 16, tukey_alpha=tukey_alpha
-)
-L1.load_data(
-    gps, duration, 2, fmin, fmax, psd_pad=duration + 16, tukey_alpha=tukey_alpha
-)
-V1.load_data(
-    gps, duration, 2, fmin, fmax, psd_pad=duration + 16, tukey_alpha=tukey_alpha
-)
+    # set PSD (Welch estimate)
+    psd_data = Data.from_gwosc(ifo.name, psd_start, psd_end)
+    # set an NFFT corresponding to the analysis segment duration
+    psd_fftlength = strain_data.duration * strain_data.sampling_frequency
+    ifo.set_psd(psd_data.to_psd(nperseg=psd_fftlength))
 
+###########################################
+########## Set up waveform ################
+###########################################
 
-waveform = RippleIMRPhenomPv2(f_ref=f_ref)
+# initialize waveform
+waveform = RippleIMRPhenomPv2(f_ref=20)
 
 ###########################################
 ########## Set up priors ##################
@@ -81,8 +89,8 @@ q_prior = UniformPrior(q_min, q_max, parameter_names=["q"])
 prior = prior + [Mc_prior, q_prior]
 
 # Spin prior
-s1_prior = UniformSpherePrior(parameter_names=["s1"], max_mag = 0.05)
-s2_prior = UniformSpherePrior(parameter_names=["s2"], max_mag = 0.05)
+s1_prior = UniformSpherePrior(parameter_names=["s1"], max_mag=0.05)
+s2_prior = UniformSpherePrior(parameter_names=["s2"], max_mag=0.05)
 iota_prior = SinePrior(parameter_names=["iota"])
 
 prior = prior + [
@@ -117,19 +125,19 @@ sample_transforms = [
     GeocentricArrivalPhaseToDetectorArrivalPhaseTransform(gps_time=gps, ifo=ifos[0]),
     GeocentricArrivalTimeToDetectorArrivalTimeTransform(tc_min=t_c_prior.xmin, tc_max=t_c_prior.xmax, gps_time=gps, ifo=ifos[0]),
     SkyFrameToDetectorFrameSkyPositionTransform(gps_time=gps, ifos=ifos),
-    BoundToUnbound(name_mapping = (["M_c"], ["M_c_unbounded"]), original_lower_bound=M_c_min, original_upper_bound=M_c_max),
-    BoundToUnbound(name_mapping = (["q"], ["q_unbounded"]), original_lower_bound=q_min, original_upper_bound=q_max),
-    BoundToUnbound(name_mapping = (["s1_phi"], ["s1_phi_unbounded"]) , original_lower_bound=0.0, original_upper_bound=2 * jnp.pi),
-    BoundToUnbound(name_mapping = (["s2_phi"], ["s2_phi_unbounded"]) , original_lower_bound=0.0, original_upper_bound=2 * jnp.pi),
-    BoundToUnbound(name_mapping = (["iota"], ["iota_unbounded"]) , original_lower_bound=0.0, original_upper_bound=jnp.pi),
-    BoundToUnbound(name_mapping = (["s1_theta"], ["s1_theta_unbounded"]) , original_lower_bound=0.0, original_upper_bound=jnp.pi),
-    BoundToUnbound(name_mapping = (["s2_theta"], ["s2_theta_unbounded"]) , original_lower_bound=0.0, original_upper_bound=jnp.pi),
-    BoundToUnbound(name_mapping = (["s1_mag"], ["s1_mag_unbounded"]) , original_lower_bound=0.0, original_upper_bound=0.05),
-    BoundToUnbound(name_mapping = (["s2_mag"], ["s2_mag_unbounded"]) , original_lower_bound=0.0, original_upper_bound=0.05),
-    BoundToUnbound(name_mapping = (["phase_det"], ["phase_det_unbounded"]), original_lower_bound=0.0, original_upper_bound=2 * jnp.pi),
-    BoundToUnbound(name_mapping = (["psi"], ["psi_unbounded"]), original_lower_bound=0.0, original_upper_bound=jnp.pi),
-    BoundToUnbound(name_mapping = (["zenith"], ["zenith_unbounded"]), original_lower_bound=0.0, original_upper_bound=jnp.pi),
-    BoundToUnbound(name_mapping = (["azimuth"], ["azimuth_unbounded"]), original_lower_bound=0.0, original_upper_bound=2 * jnp.pi),
+    BoundToUnbound(name_mapping=(["M_c"], ["M_c_unbounded"]), original_lower_bound=M_c_min, original_upper_bound=M_c_max,),
+    BoundToUnbound(name_mapping=(["q"], ["q_unbounded"]), original_lower_bound=q_min, original_upper_bound=q_max,),
+    BoundToUnbound(name_mapping=(["s1_phi"], ["s1_phi_unbounded"]), original_lower_bound=0.0, original_upper_bound=2 * jnp.pi,),
+    BoundToUnbound(name_mapping=(["s2_phi"], ["s2_phi_unbounded"]), original_lower_bound=0.0, original_upper_bound=2 * jnp.pi,),
+    BoundToUnbound(name_mapping=(["iota"], ["iota_unbounded"]), original_lower_bound=0.0, original_upper_bound=jnp.pi,),
+    BoundToUnbound(name_mapping=(["s1_theta"], ["s1_theta_unbounded"]), original_lower_bound=0.0, original_upper_bound=jnp.pi,),
+    BoundToUnbound(name_mapping=(["s2_theta"], ["s2_theta_unbounded"]), original_lower_bound=0.0, original_upper_bound=jnp.pi,),
+    BoundToUnbound(name_mapping=(["s1_mag"], ["s1_mag_unbounded"]), original_lower_bound=0.0, original_upper_bound=0.05,),
+    BoundToUnbound(name_mapping=(["s2_mag"], ["s2_mag_unbounded"]), original_lower_bound=0.0, original_upper_bound=0.05,),
+    BoundToUnbound(name_mapping=(["phase_det"], ["phase_det_unbounded"]), original_lower_bound=0.0, original_upper_bound=2 * jnp.pi,),
+    BoundToUnbound(name_mapping=(["psi"], ["psi_unbounded"]), original_lower_bound=0.0, original_upper_bound=jnp.pi,),
+    BoundToUnbound(name_mapping=(["zenith"], ["zenith_unbounded"]), original_lower_bound=0.0, original_upper_bound=jnp.pi,),
+    BoundToUnbound(name_mapping=(["azimuth"], ["azimuth_unbounded"]), original_lower_bound=0.0, original_upper_bound=2 * jnp.pi,),
 ]
 
 likelihood_transforms = [
@@ -139,16 +147,25 @@ likelihood_transforms = [
 ]
 
 
-#likelihood = TransientLikelihoodFD(
-#    [H1, L1, V1], waveform=waveform, trigger_time=trigger_time, duration=duration, post_trigger_duration=post_trigger_duration
-#)
-
-likelihood = HeterodynedTransientLikelihoodFD(ifos, waveform=waveform, n_bins = 1000, trigger_time=trigger_time, duration=duration, post_trigger_duration=post_trigger_duration, prior = prior, sample_transforms = sample_transforms, likelihood_transforms = likelihood_transforms, popsize = 10, n_steps = 50)
+likelihood = HeterodynedTransientLikelihoodFD(
+    ifos,
+    waveform=waveform,
+    n_bins=1000,
+    trigger_time=gps,
+    start_time=start,
+    prior=prior,
+    sample_transforms=sample_transforms,
+    likelihood_transforms=likelihood_transforms,
+    popsize=10,
+    n_steps=50,
+)
 
 mass_matrix = jnp.eye(prior.n_dim)
 # mass_matrix = mass_matrix.at[1, 1].set(1e-3)
 # mass_matrix = mass_matrix.at[9, 9].set(1e-3)
 local_sampler_arg = {"step_size": mass_matrix * 1e-3}
+
+#### The rest of this script is not guaranteed to work ####
 
 Adam_optimizer = optimization_Adam(n_steps=3000, learning_rate=0.01, noise_level=1)
 

--- a/example/GW170817_IMRPhenomPV2.py
+++ b/example/GW170817_IMRPhenomPV2.py
@@ -152,7 +152,6 @@ likelihood = HeterodynedTransientLikelihoodFD(
     waveform=waveform,
     n_bins=1000,
     trigger_time=gps,
-    start_time=start,
     prior=prior,
     sample_transforms=sample_transforms,
     likelihood_transforms=likelihood_transforms,

--- a/src/jimgw/single_event/data.py
+++ b/src/jimgw/single_event/data.py
@@ -202,11 +202,10 @@ class Data(ABC):
             return self.fd
         if window is None:
             window = self.window
-        
+
         logging.info(f"Computing FFT of {self.name} data")
         self.fd = jnp.fft.rfft(self.td * window) * self.delta_t
         self.window = window
-        self.has_fd = True
 
     def frequency_slice(
             self, f_min: float, f_max: float, auto_fft: bool = True
@@ -222,12 +221,10 @@ class Data(ABC):
         Returns:
             tuple: Sliced data in the frequency domain and corresponding frequencies.
         """
-        if auto_fft and not self.has_fd:
-            self.fft()
-        f = self.frequencies
+        self.fft()
+        mask = (self.frequencies >= f_min) * (self.frequencies <= f_max)
 
-        return self.fd[(f >= f_min) & (f <= f_max)], \
-            f[(f >= f_min) & (f <= f_max)]
+        return self.fd[mask], self.frequencies[mask]
 
     def to_psd(self, **kws) -> "PowerSpectrum":
         """Compute a Welch estimate of the power spectral density of the data.

--- a/src/jimgw/single_event/data.py
+++ b/src/jimgw/single_event/data.py
@@ -189,7 +189,7 @@ class Data(ABC):
 
     def fft(
         self, window: Optional[Float[Array, " n_time"]] = None
-    ) -> Float[Array, " n_freq"]:
+    ) -> Complex[Array, " n_freq"]:
         """Compute the Fourier transform of the data and store it
         in the fd attribute.
 
@@ -201,6 +201,7 @@ class Data(ABC):
         if self.has_fd and (window is None or window == self.window):
             # Perhaps one needs to also check self.td and self.delta_t are the same.
             logging.debug(f"{self.name} has FD data, skipping FFT.")
+            return self.fd
         if window is None:
             window = self.window
 

--- a/src/jimgw/single_event/data.py
+++ b/src/jimgw/single_event/data.py
@@ -310,7 +310,7 @@ class Data(ABC):
         f = np.arange(0, fnyq + delta_f, delta_f)
         # Form full data array
         data_fd_full = np.where(
-            (frequencies[-1] >= f) & (f >= frequencies[0]), fd, 0.0 + 0.0j
+            (frequencies[0] <= f) & (f <= frequencies[-1]), fd, 0.0 + 0.0j
         )
         # IFFT into time domain
         delta_t = 1 / (2 * fnyq)

--- a/src/jimgw/single_event/data.py
+++ b/src/jimgw/single_event/data.py
@@ -221,7 +221,8 @@ class Data(ABC):
         Returns:
             tuple: Sliced data in the frequency domain and corresponding frequencies.
         """
-        self.fft()
+        if auto_fft:
+            self.fft()
         mask = (self.frequencies >= f_min) * (self.frequencies <= f_max)
 
         return self.fd[mask], self.frequencies[mask]

--- a/src/jimgw/single_event/data.py
+++ b/src/jimgw/single_event/data.py
@@ -307,10 +307,10 @@ class Data(ABC):
         if (fnyq + delta_f) % 2 == 0:
             fnyq = fnyq + delta_f
         f = np.arange(0, fnyq + delta_f, delta_f)
-        # form full data array
-        data_fd_full = np.zeros(f.shape, dtype=np.array(fd).dtype)
-        data_fd_full[(frequencies[-1] >= f) & (f >= frequencies[0])] = fd
-        data_fd_full = np.array(data_fd_full)
+        # Form full data array
+        data_fd_full = np.where(
+            (frequencies[-1] >= f) & (f >= frequencies[0]), fd, 0.0+0.0j
+        )
         # IFFT into time domain
         delta_t = 1 / (2 * fnyq)
         data_td_full = np.fft.irfft(data_fd_full) / delta_t

--- a/src/jimgw/single_event/data.py
+++ b/src/jimgw/single_event/data.py
@@ -316,17 +316,17 @@ class Data(ABC):
         delta_t = 1 / (2 * fnyq)
         data_td_full = np.fft.irfft(data_fd_full) / delta_t
         # check frequencies
-        assert np.allclose(
-            f, np.fft.rfftfreq(len(data_td_full), delta_t)
+        assert jnp.allclose(
+            f, jnp.fft.rfftfreq(len(data_td_full), delta_t)
         ), "Generated frequencies do not match the input frequencies"
         # create jd.Data object
         data = cls(data_td_full, delta_t, epoch=epoch, name=name)
         data.fd = data_fd_full
 
         d_new, f_new = data.frequency_slice(frequencies[0], frequencies[-1])
-        assert all(np.equal(d_new, fd)), "Data do not match after slicing"
+        assert all(jnp.equal(d_new, fd)), "Data do not match after slicing"
         assert all(
-            np.equal(f_new, frequencies)
+            jnp.equal(f_new, frequencies)
         ), "Frequencies do not match after slicing"
         return data
 

--- a/src/jimgw/single_event/data.py
+++ b/src/jimgw/single_event/data.py
@@ -143,7 +143,7 @@ class Data(ABC):
         self,
         td: Float[Array, " n_time"] = jnp.array([]),
         delta_t: float = 0.0,
-        epoch: Optional[float] = 0.0,
+        epoch: float = 0.0,
         name: str = "",
         window: Optional[Float[Array, " n_time"]] = None,
     ) -> None:

--- a/src/jimgw/single_event/data.py
+++ b/src/jimgw/single_event/data.py
@@ -142,8 +142,8 @@ class Data(ABC):
     def __init__(
         self,
         td: Float[Array, " n_time"] = jnp.array([]),
-        delta_t: float = 0.0,
-        epoch: float = 0.0,
+        delta_t: Float = 0.0,
+        epoch: Float = 0.0,
         name: str = "",
         window: Optional[Float[Array, " n_time"]] = None,
     ) -> None:
@@ -187,7 +187,9 @@ class Data(ABC):
         logging.info(f"Setting Tukey window to {self.name} data")
         self.window = jnp.array(tukey(self.n_time, alpha))
 
-    def fft(self, window: Optional[Float[Array, " n_time"]] = None) -> None:
+    def fft(
+        self, window: Optional[Float[Array, " n_time"]] = None
+    ) -> Float[Array, " n_freq"]:
         """Compute the Fourier transform of the data and store it
         in the fd attribute.
 
@@ -206,10 +208,11 @@ class Data(ABC):
         logging.info(f"Computing FFT of {self.name} data")
         self.fd = jnp.fft.rfft(self.td * window) * self.delta_t
         self.window = window
+        return self.fd
 
     def frequency_slice(
-            self, f_min: float, f_max: float, auto_fft: bool = True
-        ) -> tuple[Float[Array, " n_sample"], Float[Array, " n_sample"]]:
+        self, f_min: Float, f_max: Float, auto_fft: bool = True
+    ) -> tuple[Float[Array, " n_sample"], Float[Array, " n_sample"]]:
         """Slice the data in the frequency domain.
         This is the main function which interacts with the likelihood.
 
@@ -275,12 +278,12 @@ class Data(ABC):
 
     @classmethod
     def from_fd(
-            cls,
-            fd: Float[Array, " n_freq"],
-            frequencies: Float[Array, " n_freq"],
-            epoch: float = 0.0,
-            name: str = "",
-        ) -> "Data":
+        cls,
+        fd: Float[Array, " n_freq"],
+        frequencies: Float[Array, " n_freq"],
+        epoch: float = 0.0,
+        name: str = "",
+    ) -> "Data":
         """Create a Data object starting from (potentially incomplete)
         Fourier domain data.
 
@@ -387,11 +390,11 @@ class PowerSpectrum(ABC):
         return self.frequencies[-1] * 2
 
     def __init__(
-            self,
-            values: Float[Array, " n_freq"] = jnp.array([]),
-            frequencies: Float[Array, " n_freq"] = jnp.array([]),
-            name: Optional[str] = None,
-        ) -> None:
+        self,
+        values: Float[Array, " n_freq"] = jnp.array([]),
+        frequencies: Float[Array, " n_freq"] = jnp.array([]),
+        name: Optional[str] = None,
+    ) -> None:
         """Initialize PowerSpectrum.
 
         Args:

--- a/src/jimgw/single_event/data.py
+++ b/src/jimgw/single_event/data.py
@@ -1,17 +1,17 @@
 __include__ = ["Data", "PowerSpectrum"]
 
 from abc import ABC
+import logging
 
-import numpy as np
-from gwpy.timeseries import TimeSeries
+import jax
+import jax.numpy as np
 from jaxtyping import Array, Float, Complex, PRNGKeyArray
+
+from gwpy.timeseries import TimeSeries
 from typing import Optional
 from scipy.interpolate import interp1d
 import scipy.signal as sig
 from scipy.signal.windows import tukey
-import logging
-import jax
-import jax.numpy as jnp
 
 
 DEG_TO_RAD = np.pi / 180
@@ -46,8 +46,8 @@ class Data(ABC):
     td: Float[Array, " n_time"]
     fd: Complex[Array, " n_time // 2 + 1"]
 
-    epoch: float
-    delta_t: float
+    epoch: Float
+    delta_t: Float
 
     window: Float[Array, " n_time"]
 
@@ -119,7 +119,7 @@ class Data(ABC):
         Returns:
             Array: Array of time points in seconds.
         """
-        return jnp.arange(self.n_time) * self.delta_t + self.epoch
+        return np.arange(self.n_time) * self.delta_t + self.epoch
 
     @property
     def frequencies(self) -> Float[Array, " n_time // 2 + 1"]:
@@ -128,7 +128,7 @@ class Data(ABC):
         Returns:
             Array: Array of frequencies in Hz.
         """
-        return jnp.fft.rfftfreq(self.n_time, self.delta_t)
+        return np.fft.rfftfreq(self.n_time, self.delta_t)
 
     @property
     def has_fd(self) -> bool:
@@ -141,7 +141,7 @@ class Data(ABC):
 
     def __init__(
         self,
-        td: Float[Array, " n_time"] = jnp.array([]),
+        td: Float[Array, " n_time"] = np.array([]),
         delta_t: Float = 0.0,
         epoch: Float = 0.0,
         name: str = "",
@@ -158,7 +158,7 @@ class Data(ABC):
         """
         self.name = name or ""
         self.td = td
-        self.fd = jnp.zeros(self.n_freq)
+        self.fd = np.zeros(self.n_freq, dtype='complex128')
         self.delta_t = delta_t
         self.epoch = epoch
         if window is None:
@@ -185,7 +185,7 @@ class Data(ABC):
                 the fraction of the segment that is tapered on each side.
         """
         logging.info(f"Setting Tukey window to {self.name} data")
-        self.window = jnp.array(tukey(self.n_time, alpha))
+        self.window = np.array(tukey(self.n_time, alpha))
 
     def fft(
         self, window: Optional[Float[Array, " n_time"]] = None
@@ -201,18 +201,17 @@ class Data(ABC):
         if self.has_fd and (window is None or window == self.window):
             # Perhaps one needs to also check self.td and self.delta_t are the same.
             logging.debug(f"{self.name} has FD data, skipping FFT.")
-            return self.fd
         if window is None:
             window = self.window
 
         logging.info(f"Computing FFT of {self.name} data")
-        self.fd = jnp.fft.rfft(self.td * window) * self.delta_t
+        self.fd = np.fft.rfft(self.td * window) * self.delta_t
         self.window = window
         return self.fd
 
     def frequency_slice(
         self, f_min: Float, f_max: Float, auto_fft: bool = True
-    ) -> tuple[Float[Array, " n_sample"], Float[Array, " n_sample"]]:
+    ) -> tuple[Complex[Array, " n_sample"], Float[Array, " n_sample"]]:
         """Slice the data in the frequency domain.
         This is the main function which interacts with the likelihood.
 
@@ -279,7 +278,7 @@ class Data(ABC):
     @classmethod
     def from_fd(
         cls,
-        fd: Float[Array, " n_freq"],
+        fd: Complex[Array, " n_freq"],
         frequencies: Float[Array, " n_freq"],
         epoch: float = 0.0,
         name: str = "",
@@ -311,10 +310,10 @@ class Data(ABC):
         # form full data array
         data_fd_full = np.zeros(f.shape, dtype=np.array(fd).dtype)
         data_fd_full[(frequencies[-1] >= f) & (f >= frequencies[0])] = fd
-        data_fd_full = jnp.array(data_fd_full)
+        data_fd_full = np.array(data_fd_full)
         # IFFT into time domain
         delta_t = 1 / (2 * fnyq)
-        data_td_full = jnp.fft.irfft(data_fd_full) / delta_t
+        data_td_full = np.fft.irfft(data_fd_full) / delta_t
         # check frequencies
         assert np.allclose(
             f, np.fft.rfftfreq(len(data_td_full), delta_t)
@@ -391,8 +390,8 @@ class PowerSpectrum(ABC):
 
     def __init__(
         self,
-        values: Float[Array, " n_freq"] = jnp.array([]),
-        frequencies: Float[Array, " n_freq"] = jnp.array([]),
+        values: Float[Array, " n_freq"] = np.array([]),
+        frequencies: Float[Array, " n_freq"] = np.array([]),
         name: Optional[str] = None,
     ) -> None:
         """Initialize PowerSpectrum.

--- a/src/jimgw/single_event/data.py
+++ b/src/jimgw/single_event/data.py
@@ -158,7 +158,7 @@ class Data(ABC):
         """
         self.name = name or ""
         self.td = td
-        self.fd = np.zeros(self.n_freq, dtype='complex128')
+        self.fd = np.zeros(self.n_freq, dtype="complex128")
         self.delta_t = delta_t
         self.epoch = epoch
         if window is None:
@@ -309,7 +309,7 @@ class Data(ABC):
         f = np.arange(0, fnyq + delta_f, delta_f)
         # Form full data array
         data_fd_full = np.where(
-            (frequencies[-1] >= f) & (f >= frequencies[0]), fd, 0.0+0.0j
+            (frequencies[-1] >= f) & (f >= frequencies[0]), fd, 0.0 + 0.0j
         )
         # IFFT into time domain
         delta_t = 1 / (2 * fnyq)

--- a/src/jimgw/single_event/detector.py
+++ b/src/jimgw/single_event/detector.py
@@ -145,7 +145,7 @@ class Detector(ABC):
         """Get frequency-domain data slice based on frequency bounds.
 
         Returns:
-            Complex[Array, " n_sample"]: Sliced frequency-domain data.
+            Complex[Array, " n_freq"]: Sliced frequency-domain data.
         """
         return self._fd_data_slice
 
@@ -154,7 +154,7 @@ class Detector(ABC):
         """Get PSD slice based on frequency bounds.
 
         Returns:
-            Float[Array, " n_sample"]: Sliced power spectral density.
+            Float[Array, " n_freq"]: Sliced power spectral density.
         """
         return self._psd_slice
 

--- a/src/jimgw/single_event/detector.py
+++ b/src/jimgw/single_event/detector.py
@@ -4,7 +4,7 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 import requests
-from jaxtyping import Array, Float, jaxtyped
+from jaxtyping import Array, Float, Complex, jaxtyped
 from beartype import beartype as typechecker
 from scipy.interpolate import interp1d
 from jimgw.single_event import data as jd
@@ -117,11 +117,38 @@ class Detector(ABC):
         psd, freqs_2 = self.psd.frequency_slice(*self.frequency_bounds)
 
         assert all(freqs_1 == freqs_2), \
-            f"The {self.name} data and PSD must have same frequencies"
+                f"The {self.name} data and PSD must have same frequencies"
 
-        self.sliced_frequencies = freqs_1
-        self.fd_data_slice = data
-        self.psd_slice = psd
+        self._sliced_frequencies = freqs_1
+        self._fd_data_slice = data
+        self._psd_slice = psd
+
+    @property
+    def sliced_frequencies(self) -> Float[Array, " n_freq"]:
+        """Get frequency-domain data slice based on frequency bounds.
+
+        Returns:
+            Float[Array, " n_sample"]: Sliced frequency-domain data.
+        """
+        return self._sliced_frequencies
+
+    @property
+    def fd_data_slice(self) -> Complex[Array, " n_freq"]:
+        """Get frequency-domain data slice based on frequency bounds.
+
+        Returns:
+            Complex[Array, " n_sample"]: Sliced frequency-domain data.
+        """
+        return self._fd_data_slice
+
+    @property
+    def psd_slice(self) -> Float[Array, " n_freq"]:
+        """Get PSD slice based on frequency bounds.
+
+        Returns:
+            Float[Array, " n_sample"]: Sliced power spectral density.
+        """
+        return self._psd_slice
 
 
 class GroundBased2G(Detector):

--- a/src/jimgw/single_event/detector.py
+++ b/src/jimgw/single_event/detector.py
@@ -292,6 +292,37 @@ class GroundBased2G(Detector):
         z = ((minor / major) ** 2 * r + h) * jnp.sin(lat)
         return jnp.array([x, y, z])
 
+    def fd_full_response(
+        self,
+        frequency: Float[Array, " n_sample"],
+        h_sky: dict[str, Float[Array, " n_sample"]],
+        params: dict[str, Float],
+        trigger_time: Float=0.0
+    ) -> Array:
+        """Project the frequency-domain waveform onto the detector response, 
+        and apply the time shift to align the peak time to the data.
+
+        Args:
+            frequency (Float[Array, " n_sample"]): Array of frequency samples.
+            h_sky (dict[str, Float[Array, " n_sample"]]): Dictionary mapping polarization names
+                to frequency-domain waveforms. Keys are polarization names (e.g., 'plus', 'cross')
+                and values are complex strain arrays.
+            params (dict[str, Float]): Dictionary of source parameters containing:
+                - ra (Float): Right ascension in radians
+                - dec (Float): Declination in radians
+                - psi (Float): Polarization angle in radians
+                - gmst (Float): Greenwich mean sidereal time in radians
+            trigger_time (Float): Trigger time of the data in seconds.
+
+        Returns:
+            Array: Complex strain measured by the detector in frequency domain, obtained by
+                  combining the antenna patterns and time delays for each polarization mode.
+        """
+        projected_h = self.fd_response(frequency, h_sky, params)
+        trigger_time_shift = trigger_time - self.epoch + params["t_c"]
+        phase_shift = jnp.exp(-2j * jnp.pi * frequency * trigger_time_shift)
+        return projected_h * phase_shift
+
     def fd_response(
         self,
         frequency: Float[Array, " n_sample"],

--- a/src/jimgw/single_event/detector.py
+++ b/src/jimgw/single_event/detector.py
@@ -7,7 +7,6 @@ import requests
 from jaxtyping import Array, Float, jaxtyped
 from beartype import beartype as typechecker
 from scipy.interpolate import interp1d
-from scipy.signal.windows import tukey
 from jimgw.single_event import data as jd
 from typing import Optional
 
@@ -114,12 +113,12 @@ class Detector(ABC):
         self.frequency_bounds = tuple(bounds)  # type: ignore
 
         # Compute sliced frequencies, data and psd.
-        data, freqs_1  = self.data.frequency_slice(**self.frequency_bounds)
-        psd, freqs_2 = self.psd.frequency_slice(**self.frequency_bounds)
+        data, freqs_1  = self.data.frequency_slice(*self.frequency_bounds)
+        psd, freqs_2 = self.psd.frequency_slice(*self.frequency_bounds)
 
         assert all(freqs_1 == freqs_2), \
             f"The {self.name} data and PSD must have same frequencies"
-        
+
         self.sliced_frequencies = freqs_1
         self.fd_data_slice = data
         self.psd_slice = psd

--- a/src/jimgw/single_event/detector.py
+++ b/src/jimgw/single_event/detector.py
@@ -364,7 +364,9 @@ class GroundBased2G(Detector):
             h_sky,
             antenna_pattern,
         )
-        projected_strain = jnp.sum(jnp.stack(jax.tree_util.tree_leaves(h_detector)), axis=0)
+        projected_strain = jnp.sum(
+            jnp.stack(jax.tree_util.tree_leaves(h_detector)), axis=0
+        )
         trigger_time_shift = trigger_time - self.epoch + params["t_c"]
         phase_shift = jnp.exp(-2j * jnp.pi * frequency * trigger_time_shift)
         return projected_strain * phase_shift

--- a/src/jimgw/single_event/detector.py
+++ b/src/jimgw/single_event/detector.py
@@ -42,6 +42,10 @@ class Detector(ABC):
 
     frequency_bounds: tuple[float, float] = (0.0, float("inf"))
 
+    _sliced_frequencies: Float[Array, " n_sample"] = jnp.array([])
+    _fd_data_slice: Float[Array, " n_sample"] = jnp.array([])
+    _psd_slice: Float[Array, " n_sample"] = jnp.array([])
+
     @property
     def epoch(self):
         """The epoch of the data."""

--- a/src/jimgw/single_event/detector.py
+++ b/src/jimgw/single_event/detector.py
@@ -23,6 +23,7 @@ asd_file_dict = {
     "V1": "https://dcc.ligo.org/public/0169/P2000251/001/O3-V1_sensitivity_strain_asd.txt",
 }
 
+
 class Detector(ABC):
     """Base class for all detectors.
 
@@ -40,12 +41,11 @@ class Detector(ABC):
     data: jd.Data
     psd: jd.PowerSpectrum
 
-    frequency_bounds: tuple[float, float] = (0., float("inf"))
+    frequency_bounds: tuple[float, float] = (0.0, float("inf"))
 
     @property
     def epoch(self):
-        """The epoch of the data.
-        """
+        """The epoch of the data."""
         return self.data.epoch
 
     @abstractmethod
@@ -96,8 +96,9 @@ class Detector(ABC):
         """
         pass
 
-    def set_frequency_bounds(self, f_min: Optional[float] = None,
-                             f_max: Optional[float] = None) -> None:
+    def set_frequency_bounds(
+        self, f_min: Optional[float] = None, f_max: Optional[float] = None
+    ) -> None:
         """Set the frequency bounds for the detector.
 
         Args:
@@ -151,6 +152,7 @@ class GroundBased2G(Detector):
         data (jd.Data): Array of Fourier-domain strain data.
         psd (jd.PowerSpectrum): Power spectral density object.
     """
+
     polarization_mode: list[Polarization]
     data: jd.Data
     psd: jd.PowerSpectrum
@@ -166,10 +168,18 @@ class GroundBased2G(Detector):
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({self.name})"
 
-    def __init__(self, name: str, latitude: float = 0, longitude: float = 0,
-                 elevation: float = 0, xarm_azimuth: float = 0,
-                 yarm_azimuth: float = 0, xarm_tilt: float = 0,
-                 yarm_tilt: float = 0, modes: str = "pc"):
+    def __init__(
+        self,
+        name: str,
+        latitude: float = 0,
+        longitude: float = 0,
+        elevation: float = 0,
+        xarm_azimuth: float = 0,
+        yarm_azimuth: float = 0,
+        xarm_tilt: float = 0,
+        yarm_tilt: float = 0,
+        modes: str = "pc",
+    ):
         """Initialize a ground-based detector.
 
         Args:
@@ -214,14 +224,10 @@ class GroundBased2G(Detector):
         """
         e_lon = jnp.array([-jnp.sin(lon), jnp.cos(lon), 0])
         e_lat = jnp.array(
-            [-jnp.sin(lat) * jnp.cos(lon),
-             -jnp.sin(lat) * jnp.sin(lon),
-             jnp.cos(lat)]
+            [-jnp.sin(lat) * jnp.cos(lon), -jnp.sin(lat) * jnp.sin(lon), jnp.cos(lat)]
         )
         e_h = jnp.array(
-            [jnp.cos(lat) * jnp.cos(lon),
-             jnp.cos(lat) * jnp.sin(lon),
-             jnp.sin(lat)]
+            [jnp.cos(lat) * jnp.cos(lon), jnp.cos(lat) * jnp.sin(lon), jnp.sin(lat)]
         )
 
         return (
@@ -284,8 +290,8 @@ class GroundBased2G(Detector):
         h = self.elevation
         major, minor = EARTH_SEMI_MAJOR_AXIS, EARTH_SEMI_MINOR_AXIS
         # compute vertex location
-        r = major ** 2 * (
-            major ** 2 * jnp.cos(lat) ** 2 + minor ** 2 * jnp.sin(lat) ** 2
+        r = major**2 * (
+            major**2 * jnp.cos(lat) ** 2 + minor**2 * jnp.sin(lat) ** 2
         ) ** (-0.5)
         x = (r + h) * jnp.cos(lat) * jnp.cos(lon)
         y = (r + h) * jnp.cos(lat) * jnp.sin(lon)
@@ -297,9 +303,9 @@ class GroundBased2G(Detector):
         frequency: Float[Array, " n_sample"],
         h_sky: dict[str, Float[Array, " n_sample"]],
         params: dict[str, Float],
-        trigger_time: Float=0.0
+        trigger_time: Float = 0.0,
     ) -> Array:
-        """Project the frequency-domain waveform onto the detector response, 
+        """Project the frequency-domain waveform onto the detector response,
         and apply the time shift to align the peak time to the data.
 
         Args:
@@ -407,7 +413,9 @@ class GroundBased2G(Detector):
         )
         return jnp.dot(omega, delta_d) / C_SI
 
-    def antenna_pattern(self, ra: Float, dec: Float, psi: Float, gmst: Float) -> dict[str, Float]:
+    def antenna_pattern(
+        self, ra: Float, dec: Float, psi: Float, gmst: Float
+    ) -> dict[str, Float]:
         """Compute antenna patterns for polarizations at specified sky location.
 
         In the long-wavelength approximation, the antenna pattern for a
@@ -453,7 +461,7 @@ class GroundBased2G(Detector):
             data = requests.get(url)
             open(self.name + ".txt", "wb").write(data.content)
             f, asd_vals = np.loadtxt(self.name + ".txt", unpack=True)
-            psd_vals = asd_vals ** 2
+            psd_vals = asd_vals**2
         else:
             f, psd_vals = np.loadtxt(psd_file, unpack=True)
 

--- a/src/jimgw/single_event/detector.py
+++ b/src/jimgw/single_event/detector.py
@@ -117,11 +117,12 @@ class Detector(ABC):
         self.frequency_bounds = tuple(bounds)  # type: ignore
 
         # Compute sliced frequencies, data and psd.
-        data, freqs_1  = self.data.frequency_slice(*self.frequency_bounds)
+        data, freqs_1 = self.data.frequency_slice(*self.frequency_bounds)
         psd, freqs_2 = self.psd.frequency_slice(*self.frequency_bounds)
 
-        assert all(freqs_1 == freqs_2), \
-                f"The {self.name} data and PSD must have same frequencies"
+        assert all(
+            freqs_1 == freqs_2
+        ), f"The {self.name} data and PSD must have same frequencies"
 
         self._sliced_frequencies = freqs_1
         self._fd_data_slice = data

--- a/src/jimgw/single_event/likelihood.py
+++ b/src/jimgw/single_event/likelihood.py
@@ -301,7 +301,7 @@ class HeterodynedTransientLikelihoodFD(TransientLikelihoodFD):
         h_sky_low = reference_waveform(self.freq_grid_low, self.ref_params)
         h_sky_center = reference_waveform(self.freq_grid_center, self.ref_params)
 
-        for detector, data, psd in zip(self.detectors, self.datas, self.psds):
+        for detector in self.detectors:
             # Get the reference waveforms
             waveform_ref = detector.fd_response(
                 frequency_original, h_sky, self.ref_params, trigger_time
@@ -313,9 +313,9 @@ class HeterodynedTransientLikelihoodFD(TransientLikelihoodFD):
                 self.freq_grid_center, h_sky_center, self.ref_params, trigger_time
             )
             A0, A1, B0, B1 = self.compute_coefficients(
-                data,
+                detector.fd_data_slice,
                 waveform_ref,
-                psd,
+                detector.psd_slice,
                 frequency_original,
                 freq_grid,
                 self.freq_grid_center,

--- a/src/jimgw/single_event/likelihood.py
+++ b/src/jimgw/single_event/likelihood.py
@@ -44,7 +44,6 @@ class TransientLikelihoodFD(SingleEventLikelihood):
         f_min: Float = 0,
         f_max: Float = float("inf"),
         trigger_time: Float = 0,
-        start_time: Float = -2,
         **kwargs,
     ) -> None:
         # NOTE: having 'kwargs' here makes it very difficult to diagnose
@@ -92,7 +91,7 @@ class TransientLikelihoodFD(SingleEventLikelihood):
 
         self.trigger_time = trigger_time
         self.duration = duration = self.detectors[0].data.duration
-        self.start_time = start_time
+        self.start_time = self.detectors[0].epoch
         self.kwargs = kwargs
         if "marginalization" in self.kwargs:
             marginalization = self.kwargs["marginalization"]
@@ -227,7 +226,6 @@ class HeterodynedTransientLikelihoodFD(TransientLikelihoodFD):
         f_max: Float = float("inf"),
         n_bins: int = 100,
         trigger_time: float = 0,
-        start_time: Float = -2,
         popsize: int = 100,
         n_steps: int = 2000,
         ref_params: dict = {},
@@ -238,7 +236,7 @@ class HeterodynedTransientLikelihoodFD(TransientLikelihoodFD):
         **kwargs,
     ) -> None:
         super().__init__(
-            detectors, waveform, f_min, f_max, trigger_time, start_time
+            detectors, waveform, f_min, f_max, trigger_time
         )
 
         logging.info("Initializing heterodyned likelihood..")

--- a/src/jimgw/single_event/likelihood.py
+++ b/src/jimgw/single_event/likelihood.py
@@ -93,7 +93,6 @@ class TransientLikelihoodFD(SingleEventLikelihood):
         self.trigger_time = trigger_time
         self.duration = duration = self.detectors[0].data.duration
         self.start_time = start_time
-        self.post_trigger_duration = start_time + duration - trigger_time
         self.kwargs = kwargs
         if "marginalization" in self.kwargs:
             marginalization = self.kwargs["marginalization"]
@@ -157,7 +156,10 @@ class TransientLikelihoodFD(SingleEventLikelihood):
     def epoch(self):
         """The epoch of the data.
         """
-        return self.duration - self.post_trigger_duration
+        # The previous definition was:
+        # post_trigger_duration = start_time + duration - trigger_time
+        # return duration - post_trigger_duration
+        return self.trigger_time - self.start_time
 
     @property
     def ifos(self):

--- a/src/jimgw/single_event/likelihood.py
+++ b/src/jimgw/single_event/likelihood.py
@@ -303,13 +303,13 @@ class HeterodynedTransientLikelihoodFD(TransientLikelihoodFD):
 
         for detector, data, psd in zip(self.detectors, self.datas, self.psds):
             # Get the reference waveforms
-            waveform_ref = detector.fd_full_response(
+            waveform_ref = detector.fd_response(
                 frequency_original, h_sky, self.ref_params, trigger_time
             )
-            self.waveform_low_ref[detector.name] = detector.fd_full_response(
+            self.waveform_low_ref[detector.name] = detector.fd_response(
                 self.freq_grid_low, h_sky_low, self.ref_params, trigger_time
             )
-            self.waveform_center_ref[detector.name] = detector.fd_full_response(
+            self.waveform_center_ref[detector.name] = detector.fd_response(
                 self.freq_grid_center, h_sky_center, self.ref_params, trigger_time
             )
             A0, A1, B0, B1 = self.compute_coefficients(
@@ -566,7 +566,7 @@ def original_likelihood(
     log_likelihood = 0.0
     for ifo in detectors:
         freqs, data, psd = ifo.sliced_frequencies, ifo.fd_data_slice, ifo.psd_slice
-        h_dec = ifo.fd_full_response(freqs, h_sky, params, trigger_time)
+        h_dec = ifo.fd_response(freqs, h_sky, params, trigger_time)
         match_filter_SNR = inner_product(h_dec, data, psd, freqs).real
         optimal_SNR = inner_product(h_dec, h_dec, psd, freqs).real
         log_likelihood += match_filter_SNR - optimal_SNR / 2
@@ -585,7 +585,7 @@ def phase_marginalized_likelihood(
     complex_d_inner_h = 0.0 + 0.0j
     for ifo in detectors:
         freqs, data, psd = ifo.sliced_frequencies, ifo.fd_data_slice, ifo.psd_slice
-        h_dec = ifo.fd_full_response(freqs, h_sky, params, trigger_time)
+        h_dec = ifo.fd_response(freqs, h_sky, params, trigger_time)
         complex_d_inner_h += inner_product(h_dec, data, psd, freqs)
         optimal_SNR = inner_product(h_dec, h_dec, psd, freqs).real
         log_likelihood += -optimal_SNR / 2
@@ -624,7 +624,7 @@ def time_marginalized_likelihood(
     complex_h_inner_d = 0.0 + 0.0j
     for ifo in detectors:
         freqs, data, psd = ifo.sliced_frequencies, ifo.fd_data_slice, ifo.psd_slice
-        h_dec = ifo.fd_full_response(freqs, h_sky, params, trigger_time)
+        h_dec = ifo.fd_response(freqs, h_sky, params, trigger_time)
         # using <h|d> instead of <d|h>
         complex_h_inner_d += inner_product(data, h_dec, psd, freqs)
         optimal_SNR = inner_product(h_dec, h_dec, psd, freqs).real
@@ -672,7 +672,7 @@ def phase_time_marginalized_likelihood(
     complex_h_inner_d = 0.0 + 0.0j
     for ifo in detectors:
         freqs, data, psd = ifo.sliced_frequencies, ifo.fd_data_slice, ifo.psd_slice
-        h_dec = ifo.fd_full_response(freqs, h_sky, params, trigger_time)
+        h_dec = ifo.fd_response(freqs, h_sky, params, trigger_time)
         # using <h|d> instead of <d|h>
         complex_h_inner_d += inner_product(data, h_dec, psd, freqs)
         optimal_SNR = inner_product(h_dec, h_dec, psd, freqs).real
@@ -729,10 +729,10 @@ def original_relative_binning_likelihood(
     log_likelihood = 0.0
 
     for detector in detectors:
-        waveform_low = detector.fd_full_response(
+        waveform_low = detector.fd_response(
             frequencies_low, waveform_sky_low, params, trigger_time
         )
-        waveform_center = detector.fd_full_response(
+        waveform_center = detector.fd_response(
             frequencies_low, waveform_sky_center, params, trigger_time
         )
 
@@ -772,10 +772,10 @@ def phase_marginalized_relative_binning_likelihood(
     complex_d_inner_h = 0.0
 
     for detector in detectors:
-        waveform_low = detector.fd_full_response(
+        waveform_low = detector.fd_response(
             frequencies_low, waveform_sky_low, params, trigger_time
         )
-        waveform_center = detector.fd_full_response(
+        waveform_center = detector.fd_response(
             frequencies_center, waveform_sky_center, params, trigger_time
         )
 

--- a/src/jimgw/single_event/likelihood.py
+++ b/src/jimgw/single_event/likelihood.py
@@ -55,7 +55,7 @@ class TransientLikelihoodFD(SingleEventLikelihood):
         for detector in detectors:
             detector.set_frequency_bounds(f_min, f_max)
             _frequencies.append(detector.sliced_frequencies)
-        assert np.all(_frequencies, axis=0).all(), "The frequency arrays are not all the same."
+        assert np.equal(_frequencies, axis=0).all(), "The frequency arrays are not all the same."
         self.detectors = detectors
         self.frequencies = _frequencies[0]
         self.waveform = waveform

--- a/src/jimgw/single_event/likelihood.py
+++ b/src/jimgw/single_event/likelihood.py
@@ -55,7 +55,7 @@ class TransientLikelihoodFD(SingleEventLikelihood):
         for detector in detectors:
             detector.set_frequency_bounds(f_min, f_max)
             _frequencies.append(detector.sliced_frequencies)
-        assert np.all(_frequencies, axis=0), "The frequency arrays are not all the same."
+        assert np.all(_frequencies, axis=0).all(), "The frequency arrays are not all the same."
         self.detectors = detectors
         self.frequencies = _frequencies[0]
         self.waveform = waveform
@@ -544,7 +544,7 @@ def inner_product(
         frequencies: Optional[Float[Array, " n_dim"]]=None,
         df: Optional[Float]=None,
     ):
-    # Note: move this function to somewhere else, maybe utils, 
+    # Note: move this function to somewhere else, maybe utils,
     # or even inside Detector.
     if df is None:
         df = frequencies[1] - frequencies[0]

--- a/src/jimgw/single_event/likelihood.py
+++ b/src/jimgw/single_event/likelihood.py
@@ -58,9 +58,7 @@ class TransientLikelihoodFD(SingleEventLikelihood):
         # make sure data has a Fourier representation
         for det in detectors:
             if not det.data:
-                raise ValueError(
-                    f"Detector {det.name} does not have data."
-                )
+                raise ValueError(f"Detector {det.name} does not have data.")
             if not det.data.has_fd:
                 logging.info("Computing FFT with default window")
                 det.data.fft()
@@ -71,12 +69,14 @@ class TransientLikelihoodFD(SingleEventLikelihood):
             datas.append(data)
             psds.append(psd)
             # make sure the psd and data are consistent
-            assert (freq_0 == freq_1).all(), \
-                f"The {det.name} data and PSD must have same frequencies"
+            assert (
+                freq_0 == freq_1
+            ).all(), f"The {det.name} data and PSD must have same frequencies"
 
         # make sure all detectors are consistent
-        assert all([(freqs[0] == freq).all() for freq in freqs]), \
-            "The detectors must have the same frequency grid"
+        assert all(
+            [(freqs[0] == freq).all() for freq in freqs]
+        ), "The detectors must have the same frequency grid"
 
         self.frequencies = freqs[0]  # type: ignore
         self.datas = datas
@@ -84,8 +84,7 @@ class TransientLikelihoodFD(SingleEventLikelihood):
 
         self.waveform = waveform
         self.gmst = (
-            Time(trigger_time, format="gps").sidereal_time("apparent",
-                                                           "greenwich").rad
+            Time(trigger_time, format="gps").sidereal_time("apparent", "greenwich").rad
         )
 
         self.trigger_time = trigger_time
@@ -151,14 +150,12 @@ class TransientLikelihoodFD(SingleEventLikelihood):
 
     @property
     def detector_names(self):
-        """The interferometers for the likelihood.
-        """
+        """The interferometers for the likelihood."""
         return [detector.name for detector in self.detectors]
 
     def evaluate(self, params: dict[str, Float], data: dict) -> Float:
         # TODO: Test whether we need to pass data in or with class changes is fine.
-        """Evaluate the likelihood for a given set of parameters.
-        """
+        """Evaluate the likelihood for a given set of parameters."""
         frequencies = self.frequencies
         params["gmst"] = self.gmst
         # adjust the params due to different marginalzation scheme
@@ -220,9 +217,7 @@ class HeterodynedTransientLikelihoodFD(TransientLikelihoodFD):
         likelihood_transforms: list[NtoMTransform] = [],
         **kwargs,
     ) -> None:
-        super().__init__(
-            detectors, waveform, f_min, f_max, trigger_time
-        )
+        super().__init__(detectors, waveform, f_min, f_max, trigger_time)
 
         logging.info("Initializing heterodyned likelihood..")
 
@@ -350,11 +345,14 @@ class HeterodynedTransientLikelihoodFD(TransientLikelihoodFD):
         for detector, data, psd in zip(self.detectors, self.datas, self.psds):
             # Get the reference waveforms
             waveform_ref = detector.fd_full_response(
-                    frequency_original, h_sky, self.ref_params, trigger_time)
+                frequency_original, h_sky, self.ref_params, trigger_time
+            )
             self.waveform_low_ref[detector.name] = detector.fd_full_response(
-                    self.freq_grid_low, h_sky_low, self.ref_params, trigger_time)
+                self.freq_grid_low, h_sky_low, self.ref_params, trigger_time
+            )
             self.waveform_center_ref[detector.name] = detector.fd_full_response(
-                    self.freq_grid_center, h_sky_center, self.ref_params, trigger_time)
+                self.freq_grid_center, h_sky_center, self.ref_params, trigger_time
+            )
             A0, A1, B0, B1 = self.compute_coefficients(
                 data,
                 waveform_ref,
@@ -603,9 +601,7 @@ def original_likelihood(
     for detector, data, psd in zip(detectors, datas, psds):
         h_dec = detector.fd_full_response(freqs, h_sky, params, trigger_time)
         # NOTE: do we want to take the slide outside the likelihood?
-        match_filter_SNR = (
-            4 * jnp.sum((jnp.conj(h_dec) * data) / psd * df).real
-        )
+        match_filter_SNR = 4 * jnp.sum((jnp.conj(h_dec) * data) / psd * df).real
         optimal_SNR = 4 * jnp.sum(jnp.conj(h_dec) * h_dec / psd * df).real
         log_likelihood += match_filter_SNR - optimal_SNR / 2
 
@@ -627,9 +623,7 @@ def phase_marginalized_likelihood(
     df = freqs[1] - freqs[0]
     for detector, data, psd in zip(detectors, datas, psds):
         h_dec = detector.fd_full_response(freqs, h_sky, params, trigger_time)
-        complex_d_inner_h += 4 * jnp.sum(
-            (jnp.conj(h_dec) * data) / psd * df
-        )
+        complex_d_inner_h += 4 * jnp.sum((jnp.conj(h_dec) * data) / psd * df)
         optimal_SNR = 4 * jnp.sum(jnp.conj(h_dec) * h_dec / psd * df).real
         log_likelihood += -optimal_SNR / 2
 
@@ -753,15 +747,19 @@ def original_relative_binning_likelihood(
     detectors,
     frequencies_low,
     frequencies_center,
-    trigger_time
+    trigger_time,
     **kwargs,
 ):
 
     log_likelihood = 0.0
 
     for detector in detectors:
-        waveform_low = detector.fd_full_response(frequencies_low, waveform_sky_low, params, trigger_time)
-        waveform_center = detector.fd_full_response(frequencies_low, waveform_sky_center, params, trigger_time)
+        waveform_low = detector.fd_full_response(
+            frequencies_low, waveform_sky_low, params, trigger_time
+        )
+        waveform_center = detector.fd_full_response(
+            frequencies_low, waveform_sky_center, params, trigger_time
+        )
 
         r0 = waveform_center / waveform_center_ref[detector.name]
         r1 = (waveform_low / waveform_low_ref[detector.name] - r0) / (
@@ -799,8 +797,12 @@ def phase_marginalized_relative_binning_likelihood(
     complex_d_inner_h = 0.0
 
     for detector in detectors:
-        waveform_low = detector.fd_full_response(frequencies_low, waveform_sky_low, params, trigger_time)
-        waveform_center = detector.fd_full_response(frequencies_center, waveform_sky_center, params, trigger_time)
+        waveform_low = detector.fd_full_response(
+            frequencies_low, waveform_sky_low, params, trigger_time
+        )
+        waveform_center = detector.fd_full_response(
+            frequencies_center, waveform_sky_center, params, trigger_time
+        )
 
         r0 = waveform_center / waveform_center_ref[detector.name]
         r1 = (waveform_low / waveform_low_ref[detector.name] - r0) / (

--- a/src/jimgw/single_event/likelihood.py
+++ b/src/jimgw/single_event/likelihood.py
@@ -117,21 +117,17 @@ class TransientLikelihoodFD(SingleEventLikelihood):
     def evaluate(self, params: dict[str, Float], data: dict) -> Float:
         # TODO: Test whether we need to pass data in or with class changes is fine.
         """Evaluate the likelihood for a given set of parameters."""
-        frequencies = self.frequencies
         params["gmst"] = self.gmst
         # adjust the params due to different marginalzation scheme
         params = self.param_func(params)
         # adjust the params due to fixing parameters
         params = self.fixing_func(params)
         # evaluate the waveform as usual
-        waveform_sky = self.waveform(frequencies, params)
+        waveform_sky = self.waveform(self.frequencies, params)
         return self.likelihood_function(
             params,
             waveform_sky,
             self.detectors,
-            frequencies,
-            self.datas,
-            self.psds,
             self.trigger_time,
             **self.kwargs,
         )
@@ -196,9 +192,7 @@ class HeterodynedTransientLikelihoodFD(TransientLikelihoodFD):
             if self.marginalization == "phase":
                 self.param_func = lambda x: {**x, "phase_c": 0.0}
                 self.likelihood_function = phase_marginalized_likelihood
-                self.rb_likelihood_function = (
-                    phase_marginalized_relative_binning_likelihood
-                )
+                self.rb_likelihood_function = phase_marginalized_relative_binning_likelihood
                 logging.info("Marginalizing over phase")
         else:
             self.param_func = lambda x: x
@@ -365,21 +359,17 @@ class HeterodynedTransientLikelihoodFD(TransientLikelihoodFD):
         """
         Evaluate the likelihood for a given set of parameters.
         """
-        frequencies = self.frequencies
         params["gmst"] = self.gmst
         # adjust the params due to different marginalzation scheme
         params = self.param_func(params)
         # adjust the params due to fixing parameters
         params = self.fixing_func(params)
         # evaluate the waveform as usual
-        waveform_sky = self.waveform(frequencies, params)
+        waveform_sky = self.waveform(self.frequencies, params)
         return self.likelihood_function(
             params,
             waveform_sky,
             self.detectors,
-            frequencies,
-            self.datas,
-            self.psds,
             self.trigger_time,
             **self.kwargs,
         )
@@ -584,9 +574,6 @@ def phase_marginalized_likelihood(
     params: dict[str, Float],
     h_sky: dict[str, Float[Array, " n_dim"]],
     detectors: list[Detector],
-    freqs: Float[Array, " n_dim"],
-    datas: list[Float[Array, " n_dim"]],
-    psds: list[Float[Array, " n_dim"]],
     trigger_time: Float,
     **kwargs,
 ) -> Float:
@@ -626,9 +613,6 @@ def time_marginalized_likelihood(
     params: dict[str, Float],
     h_sky: dict[str, Float[Array, " n_dim"]],
     detectors: list[Detector],
-    freqs: Float[Array, " n_dim"],
-    datas: list[Float[Array, " n_dim"]],
-    psds: list[Float[Array, " n_dim"]],
     trigger_time: Float,
     **kwargs,
 ) -> Float:
@@ -677,9 +661,6 @@ def phase_time_marginalized_likelihood(
     params: dict[str, Float],
     h_sky: dict[str, Float[Array, " n_dim"]],
     detectors: list[Detector],
-    freqs: Float[Array, " n_dim"],
-    datas: list[Float[Array, " n_dim"]],
-    psds: list[Float[Array, " n_dim"]],
     trigger_time: Float,
     **kwargs,
 ) -> Float:

--- a/src/jimgw/single_event/likelihood.py
+++ b/src/jimgw/single_event/likelihood.py
@@ -55,7 +55,8 @@ class TransientLikelihoodFD(SingleEventLikelihood):
         for detector in detectors:
             detector.set_frequency_bounds(f_min, f_max)
             _frequencies.append(detector.sliced_frequencies)
-        assert np.equal(_frequencies, axis=0).all(), "The frequency arrays are not all the same."
+        assert jax.tree.reduce(jnp.array_equal, _frequencies), \
+               "The frequency arrays are not all the same."
         self.detectors = detectors
         self.frequencies = _frequencies[0]
         self.waveform = waveform

--- a/src/jimgw/single_event/likelihood.py
+++ b/src/jimgw/single_event/likelihood.py
@@ -55,8 +55,9 @@ class TransientLikelihoodFD(SingleEventLikelihood):
         for detector in detectors:
             detector.set_frequency_bounds(f_min, f_max)
             _frequencies.append(detector.sliced_frequencies)
-        assert jax.tree.reduce(jnp.array_equal, _frequencies), \
-               "The frequency arrays are not all the same."
+        assert jax.tree.reduce(
+            jnp.array_equal, _frequencies
+        ), "The frequency arrays are not all the same."
         self.detectors = detectors
         self.frequencies = _frequencies[0]
         self.waveform = waveform
@@ -193,7 +194,9 @@ class HeterodynedTransientLikelihoodFD(TransientLikelihoodFD):
             if self.marginalization == "phase":
                 self.param_func = lambda x: {**x, "phase_c": 0.0}
                 self.likelihood_function = phase_marginalized_likelihood
-                self.rb_likelihood_function = phase_marginalized_relative_binning_likelihood
+                self.rb_likelihood_function = (
+                    phase_marginalized_relative_binning_likelihood
+                )
                 logging.info("Marginalizing over phase")
         else:
             self.param_func = lambda x: x
@@ -539,12 +542,12 @@ likelihood_presets = {
 
 
 def inner_product(
-        array_1: Float[Array, " n_dim"],
-        array_2: Float[Array, " n_dim"],
-        psd: Float[Array, " n_dim"],
-        frequencies: Optional[Float[Array, " n_dim"]]=None,
-        df: Optional[Float]=None,
-    ):
+    array_1: Float[Array, " n_dim"],
+    array_2: Float[Array, " n_dim"],
+    psd: Float[Array, " n_dim"],
+    frequencies: Optional[Float[Array, " n_dim"]] = None,
+    df: Optional[Float] = None,
+):
     # Note: move this function to somewhere else, maybe utils,
     # or even inside Detector.
     if df is None:
@@ -592,7 +595,7 @@ def phase_marginalized_likelihood(
 
 
 def _get_tc_array(duration: Float, sampling_rate: Float):
-    return jnp.fft.fftfreq(int(duration * sampling_rate / 2), 1/duration)
+    return jnp.fft.fftfreq(int(duration * sampling_rate / 2), 1 / duration)
 
 
 def _get_frequencies_pads(detector: Detector, fs: Float) -> tuple[Float, Float]:

--- a/src/jimgw/single_event/likelihood.py
+++ b/src/jimgw/single_event/likelihood.py
@@ -51,6 +51,10 @@ class TransientLikelihoodFD(SingleEventLikelihood):
         # explicitly what the arguments are accepted
         self.detectors = detectors
 
+        # collect the data, psd and frequencies for the requested band
+        freqs = []
+        datas = []
+        psds = []
         # make sure data has a Fourier representation
         for det in detectors:
             if not det.data:
@@ -61,19 +65,14 @@ class TransientLikelihoodFD(SingleEventLikelihood):
                 logging.info("Computing FFT with default window")
                 det.data.fft()
 
-        # collect the data, psd and frequencies for the requested band
-        freqs = []
-        datas = []
-        psds = []
-        for detector in detectors:
-            data, freq_0 = detector.data.frequency_slice(f_min, f_max)
-            psd, freq_1 = detector.psd.frequency_slice(f_min, f_max)
+            data, freq_0 = det.data.frequency_slice(f_min, f_max)
+            psd, freq_1 = det.psd.frequency_slice(f_min, f_max)
             freqs.append(freq_0)
             datas.append(data)
             psds.append(psd)
             # make sure the psd and data are consistent
             assert (freq_0 == freq_1).all(), \
-                f"The {detector.name} data and PSD must have same frequencies"
+                f"The {det.name} data and PSD must have same frequencies"
 
         # make sure all detectors are consistent
         assert all([(freqs[0] == freq).all() for freq in freqs]), \
@@ -91,7 +90,6 @@ class TransientLikelihoodFD(SingleEventLikelihood):
 
         self.trigger_time = trigger_time
         self.duration = duration = self.detectors[0].data.duration
-        self.start_time = self.detectors[0].epoch
         self.kwargs = kwargs
         if "marginalization" in self.kwargs:
             marginalization = self.kwargs["marginalization"]
@@ -152,16 +150,7 @@ class TransientLikelihoodFD(SingleEventLikelihood):
             self.fixing_func = lambda x: x
 
     @property
-    def epoch(self):
-        """The epoch of the data.
-        """
-        # The previous definition was:
-        # post_trigger_duration = start_time + duration - trigger_time
-        # return duration - post_trigger_duration
-        return self.trigger_time - self.start_time
-
-    @property
-    def ifos(self):
+    def detector_names(self):
         """The interferometers for the likelihood.
         """
         return [detector.name for detector in self.detectors]
@@ -178,20 +167,16 @@ class TransientLikelihoodFD(SingleEventLikelihood):
         params = self.fixing_func(params)
         # evaluate the waveform as usual
         waveform_sky = self.waveform(frequencies, params)
-        align_time = jnp.exp(
-            -1j * 2 * jnp.pi * frequencies * (self.epoch + params["t_c"])
-        )
-        log_likelihood = self.likelihood_function(
+        return self.likelihood_function(
             params,
             waveform_sky,
             self.detectors,
             frequencies,
             self.datas,
             self.psds,
-            align_time,
+            self.trigger_time,
             **self.kwargs,
         )
-        return log_likelihood
 
 
 class HeterodynedTransientLikelihoodFD(TransientLikelihoodFD):
@@ -362,28 +347,14 @@ class HeterodynedTransientLikelihoodFD(TransientLikelihoodFD):
         h_sky_low = reference_waveform(self.freq_grid_low, self.ref_params)
         h_sky_center = reference_waveform(self.freq_grid_center, self.ref_params)
 
-        time_shift_2pi = 2 * jnp.pi * (self.epoch + self.ref_params["t_c"])
-        # Get phase shifts to align time of coalescence
-        align_time = jnp.exp(-1j * time_shift_2pi * frequency_original)
-        align_time_low = jnp.exp(-1j * time_shift_2pi * self.freq_grid_low)
-        align_time_center = jnp.exp(-1j * time_shift_2pi * self.freq_grid_center)
-
         for detector, data, psd in zip(self.detectors, self.datas, self.psds):
             # Get the reference waveforms
-            waveform_ref = (
-                detector.fd_response(frequency_original, h_sky, self.ref_params)
-                * align_time
-            )
-            self.waveform_low_ref[detector.name] = (
-                detector.fd_response(self.freq_grid_low, h_sky_low, self.ref_params)
-                * align_time_low
-            )
-            self.waveform_center_ref[detector.name] = (
-                detector.fd_response(
-                    self.freq_grid_center, h_sky_center, self.ref_params
-                )
-                * align_time_center
-            )
+            waveform_ref = detector.fd_full_response(
+                    frequency_original, h_sky, self.ref_params, trigger_time)
+            self.waveform_low_ref[detector.name] = detector.fd_full_response(
+                    self.freq_grid_low, h_sky_low, self.ref_params, trigger_time)
+            self.waveform_center_ref[detector.name] = detector.fd_full_response(
+                    self.freq_grid_center, h_sky_center, self.ref_params, trigger_time)
             A0, A1, B0, B1 = self.compute_coefficients(
                 data,
                 waveform_ref,
@@ -409,12 +380,6 @@ class HeterodynedTransientLikelihoodFD(TransientLikelihoodFD):
         # evaluate the waveforms as usual
         waveform_sky_low = self.waveform(frequencies_low, params)
         waveform_sky_center = self.waveform(frequencies_center, params)
-        align_time_low = jnp.exp(
-            -1j * 2 * jnp.pi * frequencies_low * (self.epoch + params["t_c"])
-        )
-        align_time_center = jnp.exp(
-            -1j * 2 * jnp.pi * frequencies_center * (self.epoch + params["t_c"])
-        )
         log_likelihood = self.rb_likelihood_function(
             params,
             self.A0_array,
@@ -428,8 +393,7 @@ class HeterodynedTransientLikelihoodFD(TransientLikelihoodFD):
             self.detectors,
             frequencies_low,
             frequencies_center,
-            align_time_low,
-            align_time_center,
+            self.trigger_time,
             **self.kwargs,
         )
         return log_likelihood
@@ -442,7 +406,6 @@ class HeterodynedTransientLikelihoodFD(TransientLikelihoodFD):
         """
         Evaluate the likelihood for a given set of parameters.
         """
-        log_likelihood = 0
         frequencies = self.frequencies
         params["gmst"] = self.gmst
         # adjust the params due to different marginalzation scheme
@@ -451,20 +414,16 @@ class HeterodynedTransientLikelihoodFD(TransientLikelihoodFD):
         params = self.fixing_func(params)
         # evaluate the waveform as usual
         waveform_sky = self.waveform(frequencies, params)
-        align_time = jnp.exp(
-            -1j * 2 * jnp.pi * frequencies * (self.epoch + params["t_c"])
-        )
-        log_likelihood = self.likelihood_function(
+        return self.likelihood_function(
             params,
             waveform_sky,
             self.detectors,
             frequencies,
             self.datas,
             self.psds,
-            align_time,
+            self.trigger_time,
             **self.kwargs,
         )
-        return log_likelihood
 
     @staticmethod
     def max_phase_diff(
@@ -636,13 +595,13 @@ def original_likelihood(
     freqs: Float[Array, " n_dim"],
     datas: list[Float[Array, " n_dim"]],
     psds: list[Float[Array, " n_dim"]],
-    align_time: Float,
+    trigger_time: Float,
     **kwargs,
 ) -> Float:
     log_likelihood = 0.0
     df = freqs[1] - freqs[0]
     for detector, data, psd in zip(detectors, datas, psds):
-        h_dec = detector.fd_response(freqs, h_sky, params) * align_time
+        h_dec = detector.fd_full_response(freqs, h_sky, params, trigger_time)
         # NOTE: do we want to take the slide outside the likelihood?
         match_filter_SNR = (
             4 * jnp.sum((jnp.conj(h_dec) * data) / psd * df).real
@@ -660,14 +619,14 @@ def phase_marginalized_likelihood(
     freqs: Float[Array, " n_dim"],
     datas: list[Float[Array, " n_dim"]],
     psds: list[Float[Array, " n_dim"]],
-    align_time: Float,
+    trigger_time: Float,
     **kwargs,
 ) -> Float:
     log_likelihood = 0.0
     complex_d_inner_h = 0.0
     df = freqs[1] - freqs[0]
     for detector, data, psd in zip(detectors, datas, psds):
-        h_dec = detector.fd_response(freqs, h_sky, params) * align_time
+        h_dec = detector.fd_full_response(freqs, h_sky, params, trigger_time)
         complex_d_inner_h += 4 * jnp.sum(
             (jnp.conj(h_dec) * data) / psd * df
         )
@@ -686,7 +645,7 @@ def time_marginalized_likelihood(
     freqs: Float[Array, " n_dim"],
     datas: list[Float[Array, " n_dim"]],
     psds: list[Float[Array, " n_dim"]],
-    align_time: Float,
+    trigger_time: Float,
     **kwargs,
 ) -> Float:
     log_likelihood = 0.0
@@ -694,7 +653,7 @@ def time_marginalized_likelihood(
     # using <h|d> instead of <d|h>
     complex_h_inner_d = jnp.zeros_like(freqs)
     for detector, data, psd in zip(detectors, datas, psds):
-        h_dec = detector.fd_response(freqs, h_sky, params) * align_time
+        h_dec = detector.fd_full_response(freqs, h_sky, params, trigger_time)
         complex_h_inner_d += 4 * h_dec * jnp.conj(data) / psd * df
         optimal_SNR = 4 * jnp.sum(jnp.conj(h_dec) * h_dec / psd * df).real
         log_likelihood += -optimal_SNR / 2
@@ -737,7 +696,7 @@ def phase_time_marginalized_likelihood(
     freqs: Float[Array, " n_dim"],
     datas: list[Float[Array, " n_dim"]],
     psds: list[Float[Array, " n_dim"]],
-    align_time: Float,
+    trigger_time: Float,
     **kwargs,
 ) -> Float:
     log_likelihood = 0.0
@@ -745,7 +704,7 @@ def phase_time_marginalized_likelihood(
     # using <h|d> instead of <d|h>
     complex_h_inner_d = jnp.zeros_like(freqs)
     for detector, data, psd in zip(detectors, datas, psds):
-        h_dec = detector.fd_response(freqs, h_sky, params) * align_time
+        h_dec = detector.fd_full_response(freqs, h_sky, params, trigger_time)
         complex_h_inner_d += 4 * h_dec * jnp.conj(data) / psd * df
         optimal_SNR = 4 * jnp.sum(jnp.conj(h_dec) * h_dec / psd * df).real
         log_likelihood += -optimal_SNR / 2
@@ -794,22 +753,15 @@ def original_relative_binning_likelihood(
     detectors,
     frequencies_low,
     frequencies_center,
-    align_time_low,
-    align_time_center,
+    trigger_time
     **kwargs,
 ):
 
     log_likelihood = 0.0
 
     for detector in detectors:
-        waveform_low = (
-            detector.fd_response(frequencies_low, waveform_sky_low, params)
-            * align_time_low
-        )
-        waveform_center = (
-            detector.fd_response(frequencies_center, waveform_sky_center, params)
-            * align_time_center
-        )
+        waveform_low = detector.fd_full_response(frequencies_low, waveform_sky_low, params, trigger_time)
+        waveform_center = detector.fd_full_response(frequencies_low, waveform_sky_center, params, trigger_time)
 
         r0 = waveform_center / waveform_center_ref[detector.name]
         r1 = (waveform_low / waveform_low_ref[detector.name] - r0) / (
@@ -840,22 +792,16 @@ def phase_marginalized_relative_binning_likelihood(
     detectors,
     frequencies_low,
     frequencies_center,
-    align_time_low,
-    align_time_center,
+    trigger_time,
     **kwargs,
 ):
     log_likelihood = 0.0
     complex_d_inner_h = 0.0
 
     for detector in detectors:
-        waveform_low = (
-            detector.fd_response(frequencies_low, waveform_sky_low, params)
-            * align_time_low
-        )
-        waveform_center = (
-            detector.fd_response(frequencies_center, waveform_sky_center, params)
-            * align_time_center
-        )
+        waveform_low = detector.fd_full_response(frequencies_low, waveform_sky_low, params, trigger_time)
+        waveform_center = detector.fd_full_response(frequencies_center, waveform_sky_center, params, trigger_time)
+
         r0 = waveform_center / waveform_center_ref[detector.name]
         r1 = (waveform_low / waveform_low_ref[detector.name] - r0) / (
             frequencies_low - frequencies_center

--- a/src/jimgw/single_event/transforms.py
+++ b/src/jimgw/single_event/transforms.py
@@ -137,7 +137,7 @@ class SphereSpinToCartesianSpinTransform(BijectiveTransform):
 
         def named_inverse_transform(x):
             x, y, z = x[label + "_x"], x[label + "_y"], x[label + "_z"]
-            mag = jnp.sqrt(x ** 2 + y ** 2 + z ** 2)
+            mag = jnp.sqrt(x**2 + y**2 + z**2)
             theta, phi = carte_to_spherical_angles(x, y, z)
             phi = jnp.mod(phi, 2.0 * jnp.pi)
             return {
@@ -404,7 +404,7 @@ class DistanceToSNRWeightedDistanceTransform(ConditionalBijectiveTransform):
                 antenna_pattern = ifo.antenna_pattern(ra, dec, psi, self.gmst)
                 p_mode_term = p_iota_term * antenna_pattern["p"]
                 c_mode_term = c_iota_term * antenna_pattern["c"]
-                R_dets2 += p_mode_term ** 2 + c_mode_term ** 2
+                R_dets2 += p_mode_term**2 + c_mode_term**2
 
             return jnp.sqrt(R_dets2)
 

--- a/src/jimgw/single_event/utils.py
+++ b/src/jimgw/single_event/utils.py
@@ -702,8 +702,8 @@ def cartesian_spin_to_spin_angles(
     s2hat = jnp.where(chi_2 > 0, s2_vec / chi_2, jnp.zeros_like(s2_vec))
 
     # Azimuthal and polar angles of the spin vectors
-    tilt_1, phi1 = carte_to_spherical_angles(*s1hat)
-    tilt_2, phi2 = carte_to_spherical_angles(*s2hat)
+    tilt_1, phi1 = carte_to_spherical_angles(*s1hat, default_value=0.0)
+    tilt_2, phi2 = carte_to_spherical_angles(*s2hat, default_value=0.0)
 
     phi_12 = phi2 - phi1
     phi_12 = (phi_12 + 2 * jnp.pi) % (2 * jnp.pi)  # Ensure 0 <= phi_12 < 2pi

--- a/src/jimgw/utils.py
+++ b/src/jimgw/utils.py
@@ -69,7 +69,7 @@ def safe_polar_angle(
     return jnp.where(
         (jnp.abs(x) < EPS) & (jnp.abs(y) < EPS),
         jnp.arccos(jnp.sign(z)),
-        jnp.arccos(z / jnp.sqrt(x ** 2 + y ** 2 + z ** 2)),
+        jnp.arccos(z / jnp.sqrt(x**2 + y**2 + z**2)),
     )
 
 
@@ -101,7 +101,7 @@ def carte_to_spherical_angles(
     theta = jnp.where(
         align_condition,
         jnp.arccos(jnp.sign(z)),
-        jnp.arccos(z / jnp.sqrt(x ** 2 + y ** 2 + z ** 2)),
+        jnp.arccos(z / jnp.sqrt(x**2 + y**2 + z**2)),
     )
     phi = jnp.where(
         align_condition,

--- a/test/integration/test_GW150914_D.py
+++ b/test/integration/test_GW150914_D.py
@@ -109,7 +109,6 @@ likelihood = TransientLikelihoodFD(
     f_min=fmin,
     f_max=fmax,
     trigger_time=gps,
-    start_time=start,
 )
 
 mass_matrix = jnp.eye(11)

--- a/test/integration/test_GW150914_D_heterodyne.py
+++ b/test/integration/test_GW150914_D_heterodyne.py
@@ -111,7 +111,6 @@ likelihood = HeterodynedTransientLikelihoodFD(
     f_min=fmin,
     f_max=fmax,
     trigger_time=gps,
-    start_time=start,
     sample_transforms=sample_transforms,
     likelihood_transforms=likelihood_transforms,
     n_steps=5,

--- a/test/integration/test_GW150914_D_heterodyne.py
+++ b/test/integration/test_GW150914_D_heterodyne.py
@@ -1,17 +1,27 @@
 import jax
 import jax.numpy as jnp
+jax.config.update("jax_enable_x64", True)
 
 from jimgw.jim import Jim
-from jimgw.prior import CombinePrior, UniformPrior, CosinePrior, SinePrior, PowerLawPrior
+from jimgw.prior import (
+    CombinePrior,
+    UniformPrior,
+    CosinePrior,
+    SinePrior,
+    PowerLawPrior,
+)
+from jimgw.single_event.data import Data
 from jimgw.single_event.detector import H1, L1
 from jimgw.single_event.likelihood import HeterodynedTransientLikelihoodFD
 from jimgw.single_event.waveform import RippleIMRPhenomD
 from jimgw.transforms import BoundToUnbound
-from jimgw.single_event.transforms import ComponentMassesToChirpMassSymmetricMassRatioTransform, SkyFrameToDetectorFrameSkyPositionTransform, ComponentMassesToChirpMassMassRatioTransform
+from jimgw.single_event.transforms import (
+    ComponentMassesToChirpMassSymmetricMassRatioTransform,
+    SkyFrameToDetectorFrameSkyPositionTransform,
+    ComponentMassesToChirpMassMassRatioTransform,
+)
 from jimgw.single_event.utils import Mc_q_to_m1_m2
 from flowMC.strategy.optimization import optimization_Adam
-
-jax.config.update("jax_enable_x64", True)
 
 ###########################################
 ########## First we grab data #############
@@ -21,20 +31,33 @@ jax.config.update("jax_enable_x64", True)
 gps = 1126259462.4
 duration = 4
 post_trigger_duration = 2
-start_pad = duration - post_trigger_duration
-end_pad = post_trigger_duration
+start = gps - 2
+end = gps + 2
 fmin = 20.0
 fmax = 1024.0
 
 ifos = [H1, L1]
 
 for ifo in ifos:
-    ifo.load_data(gps, start_pad, end_pad, fmin, fmax, psd_pad=16, tukey_alpha=0.2)
+    data = Data.from_gwosc(ifo.name, start, end)
+    ifo.set_data(data)
+
+    psd_data = Data.from_gwosc(ifo.name, gps-16, gps+16)
+    psd_fftlength = data.duration * data.sampling_frequency
+    ifo.set_psd(psd_data.to_psd(nperseg=psd_fftlength))
 
 M_c_min, M_c_max = 10.0, 80.0
 q_min, q_max = 0.125, 1.0
-m_1_prior = UniformPrior(Mc_q_to_m1_m2(M_c_min, q_max)[0], Mc_q_to_m1_m2(M_c_max, q_min)[0], parameter_names=["m_1"])
-m_2_prior = UniformPrior(Mc_q_to_m1_m2(M_c_min, q_min)[1], Mc_q_to_m1_m2(M_c_max, q_max)[1], parameter_names=["m_2"])
+m_1_prior = UniformPrior(
+    Mc_q_to_m1_m2(M_c_min, q_max)[0],
+    Mc_q_to_m1_m2(M_c_max, q_min)[0],
+    parameter_names=["m_1"],
+)
+m_2_prior = UniformPrior(
+    Mc_q_to_m1_m2(M_c_min, q_min)[1],
+    Mc_q_to_m1_m2(M_c_max, q_max)[1],
+    parameter_names=["m_2"],
+)
 s1z_prior = UniformPrior(-1.0, 1.0, parameter_names=["s1_z"])
 s2z_prior = UniformPrior(-1.0, 1.0, parameter_names=["s2_z"])
 dL_prior = PowerLawPrior(1.0, 2000.0, 2.0, parameter_names=["d_L"])
@@ -63,18 +86,18 @@ prior = CombinePrior(
 
 sample_transforms = [
     ComponentMassesToChirpMassMassRatioTransform,
-    BoundToUnbound(name_mapping = [["M_c"], ["M_c_unbounded"]], original_lower_bound=M_c_min, original_upper_bound=M_c_max),
-    BoundToUnbound(name_mapping = [["q"], ["q_unbounded"]], original_lower_bound=q_min, original_upper_bound=q_max),
-    BoundToUnbound(name_mapping = [["s1_z"], ["s1_z_unbounded"]] , original_lower_bound=-1.0, original_upper_bound=1.0),
-    BoundToUnbound(name_mapping = [["s2_z"], ["s2_z_unbounded"]] , original_lower_bound=-1.0, original_upper_bound=1.0),
-    BoundToUnbound(name_mapping = [["d_L"], ["d_L_unbounded"]] , original_lower_bound=0.0, original_upper_bound=2000.0),
-    BoundToUnbound(name_mapping = [["t_c"], ["t_c_unbounded"]] , original_lower_bound=-0.05, original_upper_bound=0.05),
-    BoundToUnbound(name_mapping = [["phase_c"], ["phase_c_unbounded"]] , original_lower_bound=0.0, original_upper_bound=2 * jnp.pi),
-    BoundToUnbound(name_mapping = [["iota"], ["iota_unbounded"]], original_lower_bound=0., original_upper_bound=jnp.pi),
-    BoundToUnbound(name_mapping = [["psi"], ["psi_unbounded"]], original_lower_bound=0.0, original_upper_bound=jnp.pi),
     SkyFrameToDetectorFrameSkyPositionTransform(gps_time=gps, ifos=ifos),
-    BoundToUnbound(name_mapping = [["zenith"], ["zenith_unbounded"]], original_lower_bound=0.0, original_upper_bound=jnp.pi),
-    BoundToUnbound(name_mapping = [["azimuth"], ["azimuth_unbounded"]], original_lower_bound=0.0, original_upper_bound=2 * jnp.pi),
+    BoundToUnbound(name_mapping=[["M_c"], ["M_c_unbounded"]], original_lower_bound=M_c_min, original_upper_bound=M_c_max,),
+    BoundToUnbound(name_mapping=[["q"], ["q_unbounded"]], original_lower_bound=q_min, original_upper_bound=q_max,),
+    BoundToUnbound(name_mapping=[["s1_z"], ["s1_z_unbounded"]], original_lower_bound=-1.0, original_upper_bound=1.0,),
+    BoundToUnbound(name_mapping=[["s2_z"], ["s2_z_unbounded"]], original_lower_bound=-1.0, original_upper_bound=1.0,),
+    BoundToUnbound(name_mapping=[["d_L"], ["d_L_unbounded"]], original_lower_bound=0.0, original_upper_bound=2000.0,),
+    BoundToUnbound(name_mapping=[["t_c"], ["t_c_unbounded"]], original_lower_bound=-0.05, original_upper_bound=0.05,),
+    BoundToUnbound(name_mapping=[["phase_c"], ["phase_c_unbounded"]], original_lower_bound=0.0, original_upper_bound=2 * jnp.pi,),
+    BoundToUnbound(name_mapping=[["iota"], ["iota_unbounded"]], original_lower_bound=0.0, original_upper_bound=jnp.pi,),
+    BoundToUnbound(name_mapping=[["psi"], ["psi_unbounded"]], original_lower_bound=0.0, original_upper_bound=jnp.pi,),
+    BoundToUnbound(name_mapping=[["zenith"], ["zenith_unbounded"]], original_lower_bound=0.0, original_upper_bound=jnp.pi,),
+    BoundToUnbound(name_mapping=[["azimuth"], ["azimuth_unbounded"]], original_lower_bound=0.0, original_upper_bound=2 * jnp.pi,),
 ]
 
 likelihood_transforms = [
@@ -85,15 +108,15 @@ likelihood = HeterodynedTransientLikelihoodFD(
     ifos,
     prior=prior,
     waveform=RippleIMRPhenomD(),
+    f_min=fmin,
+    f_max=fmax,
     trigger_time=gps,
-    duration=4,
-    post_trigger_duration=2,
+    start_time=start,
     sample_transforms=sample_transforms,
     likelihood_transforms=likelihood_transforms,
     n_steps=5,
     popsize=10,
 )
-
 
 mass_matrix = jnp.eye(11)
 mass_matrix = mass_matrix.at[1, 1].set(1e-3)
@@ -131,5 +154,5 @@ jim = Jim(
 )
 
 jim.sample(jax.random.PRNGKey(42))
-jim.get_samples()
-jim.print_summary()
+# jim.get_samples()
+# jim.print_summary()

--- a/test/integration/test_GW150914_Pv2.py
+++ b/test/integration/test_GW150914_Pv2.py
@@ -127,7 +127,6 @@ likelihood = TransientLikelihoodFD(
     f_min=fmin,
     f_max=fmax,
     trigger_time=gps,
-    start_time=start,
 )
 
 

--- a/test/integration/test_GW150914_Pv2.py
+++ b/test/integration/test_GW150914_Pv2.py
@@ -2,8 +2,8 @@ import time
 
 import jax
 import jax.numpy as jnp
+jax.config.update("jax_enable_x64", True)
 
-from jimgw.jim import Jim
 from jimgw.jim import Jim
 from jimgw.prior import (
     CombinePrior,
@@ -13,6 +13,7 @@ from jimgw.prior import (
     PowerLawPrior,
     UniformSpherePrior,
 )
+from jimgw.single_event.data import Data
 from jimgw.single_event.detector import H1, L1
 from jimgw.single_event.likelihood import TransientLikelihoodFD
 from jimgw.single_event.waveform import RippleIMRPhenomPv2
@@ -27,8 +28,6 @@ from jimgw.single_event.transforms import (
 )
 from flowMC.strategy.optimization import optimization_Adam
 
-jax.config.update("jax_enable_x64", True)
-
 ###########################################
 ########## First we grab data #############
 ###########################################
@@ -39,23 +38,28 @@ total_time_start = time.time()
 gps = 1126259462.4
 duration = 4
 post_trigger_duration = 2
-start_pad = duration - post_trigger_duration
-end_pad = post_trigger_duration
+start = gps - 2
+end = gps + 2
 fmin = 20.0
 fmax = 1024.0
 
 ifos = [H1, L1]
 
 for ifo in ifos:
-    ifo.load_data(gps, start_pad, end_pad, fmin, fmax, psd_pad=16, tukey_alpha=0.2)
+    data = Data.from_gwosc(ifo.name, start, end)
+    ifo.set_data(data)
+
+    psd_data = Data.from_gwosc(ifo.name, gps-16, gps+16)
+    psd_fftlength = data.duration * data.sampling_frequency
+    ifo.set_psd(psd_data.to_psd(nperseg=psd_fftlength))
 
 prior = []
 
 # Mass prior
 M_c_min, M_c_max = 10.0, 80.0
 q_min, q_max = 0.125, 1.0
-Mc_prior = UniformPrior(M_c_min, M_c_max, parameter_names=['M_c'])
-q_prior = UniformPrior(q_min, q_max, parameter_names=['q'])
+Mc_prior = UniformPrior(M_c_min, M_c_max, parameter_names=["M_c"])
+q_prior = UniformPrior(q_min, q_max, parameter_names=["q"])
 
 prior = prior + [Mc_prior, q_prior]
 
@@ -96,19 +100,19 @@ sample_transforms = [
     GeocentricArrivalPhaseToDetectorArrivalPhaseTransform(gps_time=gps, ifo=ifos[0]),
     GeocentricArrivalTimeToDetectorArrivalTimeTransform(tc_min=t_c_prior.xmin, tc_max=t_c_prior.xmax, gps_time=gps, ifo=ifos[0]),
     SkyFrameToDetectorFrameSkyPositionTransform(gps_time=gps, ifos=ifos),
-    BoundToUnbound(name_mapping = (["M_c"], ["M_c_unbounded"]), original_lower_bound=M_c_min, original_upper_bound=M_c_max),
-    BoundToUnbound(name_mapping = (["q"], ["q_unbounded"]), original_lower_bound=q_min, original_upper_bound=q_max),
-    BoundToUnbound(name_mapping = (["s1_phi"], ["s1_phi_unbounded"]) , original_lower_bound=0.0, original_upper_bound=2 * jnp.pi),
-    BoundToUnbound(name_mapping = (["s2_phi"], ["s2_phi_unbounded"]) , original_lower_bound=0.0, original_upper_bound=2 * jnp.pi),
-    BoundToUnbound(name_mapping = (["iota"], ["iota_unbounded"]) , original_lower_bound=0.0, original_upper_bound=jnp.pi),
-    BoundToUnbound(name_mapping = (["s1_theta"], ["s1_theta_unbounded"]) , original_lower_bound=0.0, original_upper_bound=jnp.pi),
-    BoundToUnbound(name_mapping = (["s2_theta"], ["s2_theta_unbounded"]) , original_lower_bound=0.0, original_upper_bound=jnp.pi),
-    BoundToUnbound(name_mapping = (["s1_mag"], ["s1_mag_unbounded"]) , original_lower_bound=0.0, original_upper_bound=0.99),
-    BoundToUnbound(name_mapping = (["s2_mag"], ["s2_mag_unbounded"]) , original_lower_bound=0.0, original_upper_bound=0.99),
-    BoundToUnbound(name_mapping = (["phase_det"], ["phase_det_unbounded"]), original_lower_bound=0.0, original_upper_bound=2 * jnp.pi),
-    BoundToUnbound(name_mapping = (["psi"], ["psi_unbounded"]), original_lower_bound=0.0, original_upper_bound=jnp.pi),
-    BoundToUnbound(name_mapping = (["zenith"], ["zenith_unbounded"]), original_lower_bound=0.0, original_upper_bound=jnp.pi),
-    BoundToUnbound(name_mapping = (["azimuth"], ["azimuth_unbounded"]), original_lower_bound=0.0, original_upper_bound=2 * jnp.pi),
+    BoundToUnbound(name_mapping=(["M_c"], ["M_c_unbounded"]), original_lower_bound=M_c_min, original_upper_bound=M_c_max,),
+    BoundToUnbound(name_mapping=(["q"], ["q_unbounded"]), original_lower_bound=q_min, original_upper_bound=q_max,),
+    BoundToUnbound(name_mapping=(["s1_phi"], ["s1_phi_unbounded"]), original_lower_bound=0.0, original_upper_bound=2 * jnp.pi,),
+    BoundToUnbound(name_mapping=(["s2_phi"], ["s2_phi_unbounded"]), original_lower_bound=0.0, original_upper_bound=2 * jnp.pi,),
+    BoundToUnbound(name_mapping=(["iota"], ["iota_unbounded"]), original_lower_bound=0.0, original_upper_bound=jnp.pi,),
+    BoundToUnbound(name_mapping=(["s1_theta"], ["s1_theta_unbounded"]), original_lower_bound=0.0, original_upper_bound=jnp.pi,),
+    BoundToUnbound(name_mapping=(["s2_theta"], ["s2_theta_unbounded"]), original_lower_bound=0.0, original_upper_bound=jnp.pi,),
+    BoundToUnbound(name_mapping=(["s1_mag"], ["s1_mag_unbounded"]), original_lower_bound=0.0, original_upper_bound=0.99,),
+    BoundToUnbound(name_mapping=(["s2_mag"], ["s2_mag_unbounded"]), original_lower_bound=0.0, original_upper_bound=0.99,),
+    BoundToUnbound(name_mapping=(["phase_det"], ["phase_det_unbounded"]), original_lower_bound=0.0, original_upper_bound=2 * jnp.pi,),
+    BoundToUnbound(name_mapping=(["psi"], ["psi_unbounded"]), original_lower_bound=0.0, original_upper_bound=jnp.pi,),
+    BoundToUnbound(name_mapping=(["zenith"], ["zenith_unbounded"]), original_lower_bound=0.0, original_upper_bound=jnp.pi,),
+    BoundToUnbound(name_mapping=(["azimuth"], ["azimuth_unbounded"]), original_lower_bound=0.0, original_upper_bound=2 * jnp.pi,),
 ]
 
 likelihood_transforms = [
@@ -120,9 +124,10 @@ likelihood_transforms = [
 likelihood = TransientLikelihoodFD(
     ifos,
     waveform=RippleIMRPhenomPv2(),
+    f_min=fmin,
+    f_max=fmax,
     trigger_time=gps,
-    duration=4,
-    post_trigger_duration=2,
+    start_time=start,
 )
 
 


### PR DESCRIPTION
This PR attempts to address #211, the issue with the apparent offset by `delta_t` that is needed to produce the right result.

In summary, this PR does the following:
1. Undo the change in #212
2. Remove the `post_trigger_duration` argument from likelihood, and infer all necessary times from the interferometer object.
3. Restructure likelihood functions to simply take in a list of detectors
4. Update the example scripts for GW150914, and also the data loading part for GW170817.
    * Also, the three integration test scripts of GW150914 (in `test/integration`)
5. Formatting with `black`