### PR TITLE
Use correct geocentric time in likelihood evaluation

### DIFF
--- a/src/jimgw/gps_times.py
+++ b/src/jimgw/gps_times.py
@@ -8,7 +8,7 @@ but none of them are JAX-compatible.
 There is the new `jax_datetime` package, but it does not compute the year and month.
 See: https://github.com/google/jax-datetime/
 '''
-from jax import config
+from jax import config, jit
 import jax.numpy as np
 config.update("jax_enable_x64", True)
 from jaxtyping import Float, Int
@@ -163,6 +163,7 @@ def gps_to_utc_date(gps_time: Float) -> tuple[Int, Int, Int, Int]:
     return utc_date_from_timestamp(GPS_EPOCH + _sec.astype(int))
 
 
+@jit
 def gps_to_julian_day(gps_time: Float) -> Float:
     """
     Convert from UTC to Julian day, this is a necessary intermediate step in
@@ -191,6 +192,7 @@ def gps_to_julian_day(gps_time: Float) -> Float:
     )
 
 
+@jit
 def greenwich_mean_sidereal_time(gps_time: Float) -> Float:
     """
     Compute the Greenwich mean sidereal time from the GPS time.
@@ -203,6 +205,7 @@ def greenwich_mean_sidereal_time(gps_time: Float) -> Float:
     return greenwich_sidereal_time(gps_time, 0.0)
 
 
+@jit
 def greenwich_sidereal_time(
         gps_time: Float,
         equation_of_equinoxes: Float) -> Float:

--- a/src/jimgw/gps_times.py
+++ b/src/jimgw/gps_times.py
@@ -106,7 +106,7 @@ UNIX_EPOCH_YEAR = 1970
 # **Someone in the future please update this**
 # This is surely not the most ideal way, but for the code to be jittable,
 # this seems to be a not too bad compromise.
-YEAR_ARRAY = np.arange(UNIX_EPOCH_YEAR, 2450)
+YEAR_ARRAY = np.arange(UNIX_EPOCH_YEAR, 2510)
 IS_LEAP_YEARS = is_leap_year(YEAR_ARRAY)
 LEAP_SEC_ARRAY = np.where(IS_LEAP_YEARS, LEAP_YEAR_SECONDS, SECONDS_IN_YEAR)
 
@@ -133,6 +133,12 @@ def utc_date_from_timestamp(timestamp: Int) -> tuple[Int, Int, Int, Int]:
     is_negative = (remaining_seconds < 0).astype(np.int64)
     year += is_more_than - is_negative
     remaining_seconds -= (is_more_than - is_negative) * sec_in_year
+
+    # This is to deal with the extreme cases (year ~2500)
+    sec_in_year = np.where(is_leap_year(year), LEAP_YEAR_SECONDS, SECONDS_IN_YEAR)
+    is_more_than = (remaining_seconds >= sec_in_year).astype(np.int64)
+    year += is_more_than
+    remaining_seconds -= is_more_than * sec_in_year
 
     # Adjust for leap year
     sec_in_months = (

--- a/src/jimgw/gps_times.py
+++ b/src/jimgw/gps_times.py
@@ -118,7 +118,10 @@ def utc_date_from_timestamp(timestamp: Int) -> tuple[Int, Int, Int, Int]:
     year = timestamp // LEAP_YEAR_SECONDS + UNIX_EPOCH_YEAR
     seconds_before = np.where(YEAR_ARRAY < year, LEAP_SEC_ARRAY, 0).sum()
 
-    assert year < 2500, f"This function is designed to work between years {UNIX_EPOCH_YEAR} and 2500. The year {year} is out of bounds."
+    # if (year < 2500):
+    #     raise ValueError(
+    #         f"This function is designed to work between years {UNIX_EPOCH_YEAR} and 2500. The year {year} is out of bounds."
+    #     )
 
     remaining_seconds = timestamp - seconds_before
     sec_in_year = np.where(is_leap_year(year), LEAP_YEAR_SECONDS, SECONDS_IN_YEAR)

--- a/src/jimgw/gps_times.py
+++ b/src/jimgw/gps_times.py
@@ -13,6 +13,10 @@ import jax.numpy as np
 config.update("jax_enable_x64", True)
 from jaxtyping import Float, Int
 
+# This UNIX timestamp is computed by: 
+# datetime(1980, 1, 6, 0, 0, 0, tzinfo=timezone.utc).timestamp()
+# Or in LAL: 
+# https://lscsoft.docs.ligo.org/lalsuite/lal/group___date__h.html#ga1c3cab00910987a1410a9d24d4fccdce
 GPS_EPOCH: int = 315964800
 EPOCH_J2000_0_JD: float = 2451545.0
 '''

--- a/src/jimgw/gps_times.py
+++ b/src/jimgw/gps_times.py
@@ -134,7 +134,7 @@ def utc_date_from_timestamp(timestamp: Int) -> tuple[Int, Int, Int, Int]:
     year += is_more_than - is_negative
     remaining_seconds -= (is_more_than - is_negative) * sec_in_year
 
-    # This is to deal with the extreme cases (year ~2500)
+    # This is to deal with the extreme cases (year ~2500)
     sec_in_year = np.where(is_leap_year(year), LEAP_YEAR_SECONDS, SECONDS_IN_YEAR)
     is_more_than = (remaining_seconds >= sec_in_year).astype(np.int64)
     year += is_more_than

--- a/src/jimgw/gps_times.py
+++ b/src/jimgw/gps_times.py
@@ -1,0 +1,235 @@
+'''
+This module computes a JAX-compatible conversion from GPS to UTC time and Julian day.
+Following the implementation in LALSuite and Bilby.
+
+The conversion from GPS time to UTC date is typically done using the following packages:
+    * datetime, astropy, numpy
+but none of them are JAX-compatible.
+There is the new `jax_datetime` package, but it does not compute the year and month.
+See: https://github.com/google/jax-datetime/
+'''
+from jax import config
+import jax.numpy as np
+config.update("jax_enable_x64", True)
+from jaxtyping import Float, Int
+
+GPS_EPOCH: int = 315964800
+EPOCH_J2000_0_JD: float = 2451545.0
+'''
+ * Leap seconds list
+ *
+ * JD and GPS time of leap seconds and the value of TAI-UTC.
+ *
+ * reference: http://maia.usno.navy.mil/
+ *            http://maia.usno.navy.mil/ser7/tai-utc.dat
+ *
+ * notes: the list below must be updated whenever a leap second is added
+ * See also: https://lscsoft.docs.ligo.org/lalsuite/lal/_x_l_a_l_leap_seconds_8h_source.html
+ * https://data.iana.org/time-zones/data/leap-seconds.list
+'''
+LEAP_SECONDS = np.array([
+    46828800,
+    78364801,
+    109900802,
+    173059203,
+    252028804,
+    315187205,
+    346723206,
+    393984007,
+    425520008,
+    457056009,
+    504489610,
+    551750411,
+    599184012,
+    820108813,
+    914803214,
+    1025136015,
+    1119744016,
+    1167264017,
+])
+
+def int_div(a: Int, b: Int) -> Int:
+    '''This is to emulate the C-style integer division in Python.
+    See: https://stackoverflow.com/a/61386872
+    '''
+    q, r = a // b, a % b
+    return np.where(
+            ((a >= 0) != (b >= 0)) & r,
+            q + 1, q)
+
+
+def n_leap_seconds(date: Int) -> Int:
+    """
+    Find the number of leap seconds required for the specified date.
+
+    Search in reverse order as in practice, almost all requested times will
+    be after the most recent leap.
+    
+    The Bilby Cython implementation:
+    NUM_LEAPS: int = 18
+    n_leaps: int = NUM_LEAPS
+
+    if date > LEAP_SECONDS[NUM_LEAPS - 1]:
+        return NUM_LEAPS
+    while (n_leaps > 0) and (date < LEAP_SECONDS[n_leaps - 1]):
+        n_leaps -= 1
+    return n_leaps
+
+    Args:
+        date (int): The date in seconds since the GPS epoch.
+    Returns:
+        int: The number of leap seconds.
+    """
+    return np.sum(date > LEAP_SECONDS).astype(np.float64)
+
+def is_leap_year(year):
+    '''Function to check if a year is a leap year.
+    '''
+    return (year % 4 == 0) & ((year % 100 != 0) | (year % 400 == 0))
+
+# Constants
+SECONDS_IN_DAY = 24 * 60 * 60
+SECONDS_IN_YEAR = 365 * SECONDS_IN_DAY
+LEAP_YEAR_SECONDS = 366 * SECONDS_IN_DAY
+MONTH_ARRAY = np.arange(1, 13)
+DAYS_IN_MONTH = np.array([31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31])
+UNIX_EPOCH_YEAR = 1970
+
+# **Someone in the future please update this**
+# This is surely not the most ideal way, but for the code to be jittable, 
+# this seems to be a not too bad compromise.
+YEAR_ARRAY = np.arange(UNIX_EPOCH_YEAR, 2500)
+IS_LEAP_YEARS = is_leap_year(YEAR_ARRAY)
+LEAP_SEC_ARRAY = np.where(IS_LEAP_YEARS, LEAP_YEAR_SECONDS, SECONDS_IN_YEAR)
+
+def utc_date_from_timestamp(timestamp: Int) -> tuple[Int, Int, Int, Int]:
+    '''
+    This function converts a UTC timestamp to a UTC date (year, month, day, seconds).
+
+    This sole intention of this function is to be JAX-compatible and be used within Jim .
+    While it has been agressively tested against the C-implementation in LAL, 
+    and the datetime module, it is advised to use those other modules for 
+    other purposes.
+
+    Note that the current implementation has an upper limit of year up to 2500, 
+    which is sufficient for most practical purposes.
+    '''
+    # The lower bound assumes every year is a leap year
+    year = timestamp // LEAP_YEAR_SECONDS + UNIX_EPOCH_YEAR
+    seconds_before = np.where(YEAR_ARRAY < year, LEAP_SEC_ARRAY, 0).sum()
+
+    assert year < 2500, f"This function is designed to work between years {UNIX_EPOCH_YEAR} and 2500. The year {year} is out of bounds."
+
+    remaining_seconds = timestamp - seconds_before
+    sec_in_year = np.where(is_leap_year(year), LEAP_YEAR_SECONDS, SECONDS_IN_YEAR)
+    is_more_than = (remaining_seconds > sec_in_year).astype(np.int32)
+    year += is_more_than
+    remaining_seconds -= is_more_than * sec_in_year
+    is_negative = (remaining_seconds < 0).astype(np.int32)
+    year -= is_negative
+    remaining_seconds += is_negative * sec_in_year
+
+    # Adjust for leap year
+    sec_in_months = np.where(
+        is_leap_year(year),
+        DAYS_IN_MONTH.at[1].set(29),
+        DAYS_IN_MONTH,
+    ) * SECONDS_IN_DAY
+    
+    month = remaining_seconds // (28 * SECONDS_IN_DAY)
+    seconds_before_mon = np.where(MONTH_ARRAY < month, sec_in_months, 0).sum()
+    month += (month == 0).astype(np.int32)
+    remaining_seconds -= seconds_before_mon
+
+    sec_in_month = sec_in_months[month - 1]
+    is_more_than = (remaining_seconds > sec_in_month).astype(np.int32)
+    month += is_more_than
+    remaining_seconds -= is_more_than * sec_in_month
+    is_negative = (remaining_seconds < 0).astype(np.int32)
+    month -= is_negative
+    remaining_seconds += is_negative * sec_in_month
+
+    # Calculate the day and seconds
+    day, seconds = divmod(remaining_seconds, SECONDS_IN_DAY)
+    return year, month, day + 1, seconds.astype(np.int32)
+
+
+def gps_to_utc_date(gps_time: Float) -> tuple[Int, Int, Int, Int]:
+    '''
+    Args:
+        gps_time (float): The GPS time to convert.
+    Returns:
+        tuple (int): A tuple containing the year, month, day, and seconds.
+    '''
+    _sec = gps_time - n_leap_seconds(gps_time)
+    return utc_date_from_timestamp(GPS_EPOCH + _sec.astype(int))
+
+
+def gps_to_julian_day(gps_time: Float) -> Float:
+    """
+    Convert from UTC to Julian day, this is a necessary intermediate step in
+    converting from GPS to GMST.
+
+    The type-cast on the second is necessary for consistency with the C
+    implementation. Without which the error is of order 0.1.
+
+    The `int_div` function is introduced to emulate the C-style integer division.
+
+    Args:
+        gps_time (float): The GPS time to convert.
+
+    Returns:
+        float: The Julian day corresponding to the given UTC time.
+    """
+    year, month, day, second = gps_to_utc_date(gps_time)
+    return (
+        367 * year
+        - int_div(7 * (year + int_div(month + 9, 12)), 4)
+        + int_div(275 * month, 9)
+        + day
+        + 1721014
+        + second.astype(float) / (60 * 60 * 24)
+        - 0.5
+    )
+
+
+def greenwich_mean_sidereal_time(gps_time: Float) -> Float:
+    """
+    Compute the Greenwich mean sidereal time from the GPS time.
+
+    Ags:
+        gps_time (float): The GPS time to convert
+    Returns:
+        float: The Greenwich mean sidereal time in radians.
+    """
+    return greenwich_sidereal_time(gps_time, 0.0)
+
+
+def greenwich_sidereal_time(
+        gps_time: Float, 
+        equation_of_equinoxes: Float) -> Float:
+    """
+    Compute the Greenwich mean sidereal time from the GPS time and equation of
+    equinoxes.
+
+    Based on XLALGreenwichSiderealTime in lalsuite/lal/lib/XLALSiderealTime.c.
+
+    Args:
+        gps_time (float): The GPS time to convert
+        equation_of_equinoxes (float): The equation of equinoxes
+    Returns:
+        float: The Greenwich sidereal time in radians.
+    """
+    julian_day = gps_to_julian_day(gps_time)
+    t_hi = (julian_day - EPOCH_J2000_0_JD) / 36525.0
+    t_lo = (gps_time % 1) / (36525.0 * 86400.0)
+
+    t = t_hi + t_lo
+
+    sidereal_time = equation_of_equinoxes + (-6.2e-6 * t + 0.093104) * t**2 + 67310.54841
+    sidereal_time += 8640184.812866 * t_lo
+    sidereal_time += 3155760000.0 * t_lo
+    sidereal_time += 8640184.812866 * t_hi
+    sidereal_time += 3155760000.0 * t_hi
+
+    return sidereal_time * np.pi / 43200.0

--- a/src/jimgw/gps_times.py
+++ b/src/jimgw/gps_times.py
@@ -102,7 +102,7 @@ UNIX_EPOCH_YEAR = 1970
 # **Someone in the future please update this**
 # This is surely not the most ideal way, but for the code to be jittable,
 # this seems to be a not too bad compromise.
-YEAR_ARRAY = np.arange(UNIX_EPOCH_YEAR, 2500)
+YEAR_ARRAY = np.arange(UNIX_EPOCH_YEAR, 2450)
 IS_LEAP_YEARS = is_leap_year(YEAR_ARRAY)
 LEAP_SEC_ARRAY = np.where(IS_LEAP_YEARS, LEAP_YEAR_SECONDS, SECONDS_IN_YEAR)
 

--- a/src/jimgw/jim.py
+++ b/src/jimgw/jim.py
@@ -1,6 +1,5 @@
 import jax
 import jax.numpy as jnp
-from collections import OrderedDict
 from flowMC.resource_strategy_bundle.RQSpline_MALA_PT import RQSpline_MALA_PT_Bundle
 from flowMC.resource.buffers import Buffer
 from flowMC.Sampler import Sampler

--- a/src/jimgw/jim.py
+++ b/src/jimgw/jim.py
@@ -1,5 +1,6 @@
 import jax
 import jax.numpy as jnp
+from collections import OrderedDict
 from flowMC.resource_strategy_bundle.RQSpline_MALA_PT import RQSpline_MALA_PT_Bundle
 from flowMC.resource.buffers import Buffer
 from flowMC.Sampler import Sampler
@@ -176,7 +177,7 @@ class Jim(object):
                 for transform in self.sample_transforms:
                     guess = jax.vmap(transform.forward)(guess)
                 guess = jnp.array(
-                    jax.tree.leaves({key: guess[key] for key in self.parameter_names})
+                    jax.tree.leaves(OrderedDict({key: guess[key] for key in self.parameter_names}))
                 ).T
                 finite_guess = jnp.where(
                     jnp.all(jax.tree.map(lambda x: jnp.isfinite(x), guess), axis=1)

--- a/src/jimgw/single_event/data.py
+++ b/src/jimgw/single_event/data.py
@@ -315,17 +315,19 @@ class Data(ABC):
         delta_t = 1 / (2 * fnyq)
         data_td_full = np.fft.irfft(data_fd_full) / delta_t
         # check frequencies
-        assert jnp.allclose(
-            f, jnp.fft.rfftfreq(len(data_td_full), delta_t)
+        assert np.allclose(
+            f, np.fft.rfftfreq(len(data_td_full), delta_t)
         ), "Generated frequencies do not match the input frequencies"
         # create jd.Data object
         data = cls(data_td_full, delta_t, epoch=epoch, name=name)
         data.fd = data_fd_full
 
+        # This ensures the newly constructed Data in FD fully
+        # represents the input FD data.
         d_new, f_new = data.frequency_slice(frequencies[0], frequencies[-1])
-        assert all(jnp.equal(d_new, fd)), "Data do not match after slicing"
+        assert all(np.equal(d_new, fd)), "Data do not match after slicing"
         assert all(
-            jnp.equal(f_new, frequencies)
+            np.equal(f_new, frequencies)
         ), "Frequencies do not match after slicing"
         return data
 

--- a/src/jimgw/single_event/data.py
+++ b/src/jimgw/single_event/data.py
@@ -202,11 +202,10 @@ class Data(ABC):
             return self.fd
         if window is None:
             window = self.window
-        
+
         logging.info(f"Computing FFT of {self.name} data")
         self.fd = jnp.fft.rfft(self.td * window) * self.delta_t
         self.window = window
-        self.has_fd = True
 
     def frequency_slice(
             self, f_min: float, f_max: float, auto_fft: bool = True
@@ -222,12 +221,10 @@ class Data(ABC):
         Returns:
             tuple: Sliced data in the frequency domain and corresponding frequencies.
         """
-        if auto_fft and not self.has_fd:
-            self.fft()
-        f = self.frequencies
+        self.fft()
+        mask = (self.frequencies >= f_min) * (self.frequencies <= f_max)
 
-        return self.fd[(f >= f_min) & (f <= f_max)], \
-            f[(f >= f_min) & (f <= f_max)]
+        return self.fd[mask], self.frequencies[mask]
 
     def to_psd(self, **kws) -> "PowerSpectrum":
         """Compute a Welch estimate of the power spectral density of the data.

--- a/src/jimgw/single_event/data.py
+++ b/src/jimgw/single_event/data.py
@@ -221,7 +221,8 @@ class Data(ABC):
         Returns:
             tuple: Sliced data in the frequency domain and corresponding frequencies.
         """
-        self.fft()
+        if auto_fft:
+            self.fft()
         mask = (self.frequencies >= f_min) * (self.frequencies <= f_max)
 
         return self.fd[mask], self.frequencies[mask]

--- a/src/jimgw/single_event/data.py
+++ b/src/jimgw/single_event/data.py
@@ -4,7 +4,7 @@ from abc import ABC
 import logging
 
 import jax
-import jax.numpy as np
+import jax.numpy as jnp
 from jaxtyping import Array, Float, Complex, PRNGKeyArray
 
 from gwpy.timeseries import TimeSeries
@@ -14,7 +14,7 @@ import scipy.signal as sig
 from scipy.signal.windows import tukey
 
 
-DEG_TO_RAD = np.pi / 180
+DEG_TO_RAD = jnp.pi / 180
 
 # TODO: Need to expand this list. Currently it is only O3.
 asd_file_dict = {
@@ -119,7 +119,7 @@ class Data(ABC):
         Returns:
             Array: Array of time points in seconds.
         """
-        return np.arange(self.n_time) * self.delta_t + self.epoch
+        return jnp.arange(self.n_time) * self.delta_t + self.epoch
 
     @property
     def frequencies(self) -> Float[Array, " n_time // 2 + 1"]:
@@ -128,7 +128,7 @@ class Data(ABC):
         Returns:
             Array: Array of frequencies in Hz.
         """
-        return np.fft.rfftfreq(self.n_time, self.delta_t)
+        return jnp.fft.rfftfreq(self.n_time, self.delta_t)
 
     @property
     def has_fd(self) -> bool:
@@ -137,11 +137,11 @@ class Data(ABC):
         Returns:
             bool: True if Fourier domain data exists, False otherwise.
         """
-        return bool(np.any(self.fd))
+        return bool(jnp.any(self.fd))
 
     def __init__(
         self,
-        td: Float[Array, " n_time"] = np.array([]),
+        td: Float[Array, " n_time"] = jnp.array([]),
         delta_t: Float = 0.0,
         epoch: Float = 0.0,
         name: str = "",
@@ -158,7 +158,7 @@ class Data(ABC):
         """
         self.name = name or ""
         self.td = td
-        self.fd = np.zeros(self.n_freq, dtype="complex128")
+        self.fd = jnp.zeros(self.n_freq, dtype="complex128")
         self.delta_t = delta_t
         self.epoch = epoch
         if window is None:
@@ -185,7 +185,7 @@ class Data(ABC):
                 the fraction of the segment that is tapered on each side.
         """
         logging.info(f"Setting Tukey window to {self.name} data")
-        self.window = np.array(tukey(self.n_time, alpha))
+        self.window = jnp.array(tukey(self.n_time, alpha))
 
     def fft(
         self, window: Optional[Float[Array, " n_time"]] = None
@@ -206,7 +206,7 @@ class Data(ABC):
             window = self.window
 
         logging.info(f"Computing FFT of {self.name} data")
-        self.fd = np.fft.rfft(self.td * window) * self.delta_t
+        self.fd = jnp.fft.rfft(self.td * window) * self.delta_t
         self.window = window
         return self.fd
 
@@ -306,17 +306,17 @@ class Data(ABC):
         # the Nyquist frequency)
         if (fnyq + delta_f) % 2 == 0:
             fnyq = fnyq + delta_f
-        f = np.arange(0, fnyq + delta_f, delta_f)
+        f = jnp.arange(0, fnyq + delta_f, delta_f)
         # Form full data array
-        data_fd_full = np.where(
+        data_fd_full = jnp.where(
             (frequencies[0] <= f) & (f <= frequencies[-1]), fd, 0.0 + 0.0j
         )
         # IFFT into time domain
         delta_t = 1 / (2 * fnyq)
-        data_td_full = np.fft.irfft(data_fd_full) / delta_t
+        data_td_full = jnp.fft.irfft(data_fd_full) / delta_t
         # check frequencies
-        assert np.allclose(
-            f, np.fft.rfftfreq(len(data_td_full), delta_t)
+        assert jnp.allclose(
+            f, jnp.fft.rfftfreq(len(data_td_full), delta_t)
         ), "Generated frequencies do not match the input frequencies"
         # create jd.Data object
         data = cls(data_td_full, delta_t, epoch=epoch, name=name)
@@ -325,9 +325,9 @@ class Data(ABC):
         # This ensures the newly constructed Data in FD fully
         # represents the input FD data.
         d_new, f_new = data.frequency_slice(frequencies[0], frequencies[-1])
-        assert all(np.equal(d_new, fd)), "Data do not match after slicing"
+        assert all(jnp.equal(d_new, fd)), "Data do not match after slicing"
         assert all(
-            np.equal(f_new, frequencies)
+            jnp.equal(f_new, frequencies)
         ), "Frequencies do not match after slicing"
         return data
 
@@ -392,8 +392,8 @@ class PowerSpectrum(ABC):
 
     def __init__(
         self,
-        values: Float[Array, " n_freq"] = np.array([]),
-        frequencies: Float[Array, " n_freq"] = np.array([]),
+        values: Float[Array, " n_freq"] = jnp.array([]),
+        frequencies: Float[Array, " n_freq"] = jnp.array([]),
         name: Optional[str] = None,
     ) -> None:
         """Initialize PowerSpectrum.
@@ -471,6 +471,6 @@ class PowerSpectrum(ABC):
         """
         key, subkey = jax.random.split(key, 2)
         var = self.values / (4 * self.delta_f)
-        noise_real = jax.random.normal(key, shape=var.shape) * np.sqrt(var)
-        noise_imag = jax.random.normal(subkey, shape=var.shape) * np.sqrt(var)
+        noise_real = jax.random.normal(key, shape=var.shape) * jnp.sqrt(var)
+        noise_imag = jax.random.normal(subkey, shape=var.shape) * jnp.sqrt(var)
         return noise_real + 1j * noise_imag

--- a/src/jimgw/single_event/data.py
+++ b/src/jimgw/single_event/data.py
@@ -143,7 +143,7 @@ class Data(ABC):
         self,
         td: Float[Array, " n_time"] = jnp.array([]),
         delta_t: float = 0.0,
-        epoch: Optional[float] = 0.0,
+        epoch: float = 0.0,
         name: str = "",
         window: Optional[Float[Array, " n_time"]] = None,
     ) -> None:

--- a/src/jimgw/single_event/detector.py
+++ b/src/jimgw/single_event/detector.py
@@ -7,7 +7,6 @@ import requests
 from jaxtyping import Array, Float, jaxtyped
 from beartype import beartype as typechecker
 from scipy.interpolate import interp1d
-from scipy.signal.windows import tukey
 from jimgw.single_event import data as jd
 from typing import Optional
 
@@ -114,12 +113,12 @@ class Detector(ABC):
         self.frequency_bounds = tuple(bounds)  # type: ignore
 
         # Compute sliced frequencies, data and psd.
-        data, freqs_1  = self.data.frequency_slice(**self.frequency_bounds)
-        psd, freqs_2 = self.psd.frequency_slice(**self.frequency_bounds)
+        data, freqs_1  = self.data.frequency_slice(*self.frequency_bounds)
+        psd, freqs_2 = self.psd.frequency_slice(*self.frequency_bounds)
 
         assert all(freqs_1 == freqs_2), \
             f"The {self.name} data and PSD must have same frequencies"
-        
+
         self.sliced_frequencies = freqs_1
         self.fd_data_slice = data
         self.psd_slice = psd

--- a/src/jimgw/single_event/detector.py
+++ b/src/jimgw/single_event/detector.py
@@ -58,7 +58,6 @@ class Detector(ABC):
         frequency: Float[Array, " n_sample"],
         h_sky: dict[str, Float[Array, " n_sample"]],
         params: dict,
-        trigger_time: Float = 0.0,
         **kwargs,
     ) -> Complex[Array, " n_sample"]:
         """Modulate the waveform in the sky frame by the detector response in the frequency domain.
@@ -72,9 +71,7 @@ class Detector(ABC):
                 - ra (float): Right ascension in radians
                 - dec (float): Declination in radians
                 - psi (float): Polarization angle in radians
-                - gmst (float): Greenwich mean sidereal time in radians
-                - t_c (Float): Difference between geocent time and trigger time in sec
-            trigger_time (Float): Trigger time of the data in seconds.
+                - geocent_time (float): The geocentric time in sec
             **kwargs: Additional keyword arguments.
 
         Returns:
@@ -345,9 +342,7 @@ class GroundBased2G(Detector):
                 - ra (Float): Right ascension in radians
                 - dec (Float): Declination in radians
                 - psi (Float): Polarization angle in radians
-                - gmst (Float): Greenwich mean sidereal time in radians
-                - t_c (Float): Difference between geocent time and trigger time in sec
-            trigger_time (Float): Trigger time of the data in seconds.
+                - geocent_time (float): The geocentric time in sec
             **kwargs: Additional keyword arguments.
 
         Returns:

--- a/src/jimgw/single_event/detector.py
+++ b/src/jimgw/single_event/detector.py
@@ -355,7 +355,7 @@ class GroundBased2G(Detector):
         ra, dec, psi, gmst = params["ra"], params["dec"], params["psi"], params["gmst"]
         antenna_pattern = self.antenna_pattern(ra, dec, psi, gmst)
         time_shift = self.delay_from_geocenter(ra, dec, gmst)
-        time_shift += params["trigger_time"] + params["t_c"] - self.epoch
+        time_shift += params["trigger_time"] - self.epoch + params["t_c"]
 
         h_detector = jax.tree_util.tree_map(
             lambda h, antenna: h * antenna,

--- a/src/jimgw/single_event/detector.py
+++ b/src/jimgw/single_event/detector.py
@@ -364,7 +364,7 @@ class GroundBased2G(Detector):
             jnp.stack(jax.tree_util.tree_leaves(h_detector)), axis=0
         )
 
-        phase_shift = jnp.exp(- 2j * jnp.pi * frequency * time_shift)
+        phase_shift = jnp.exp(-2j * jnp.pi * frequency * time_shift)
         return projected_strain * phase_shift
 
     def td_response(

--- a/src/jimgw/single_event/likelihood.py
+++ b/src/jimgw/single_event/likelihood.py
@@ -58,7 +58,7 @@ class TransientLikelihoodFD(SingleEventLikelihood):
         for detector in detectors:
             detector.set_frequency_bounds(f_min, f_max)
             _frequencies.append(detector.sliced_frequencies)
-        assert np.all(_frequencies, axis=0), "The frequency arrays are not all the same."
+        assert np.all(_frequencies, axis=0).all(), "The frequency arrays are not all the same."
         self.detectors = detectors
         self.frequencies = _frequencies[0]
         self.duration = self.detectors[0].data.duration
@@ -545,7 +545,7 @@ def inner_product(
         frequencies: Optional[Float[Array, " n_dim"]]=None,
         df: Optional[Float]=None,
     ):
-    # Note: move this function to somewhere else, maybe utils, 
+    # Note: move this function to somewhere else, maybe utils,
     # or even inside Detector.
     if df is None:
         df = frequencies[1] - frequencies[0]

--- a/src/jimgw/single_event/likelihood.py
+++ b/src/jimgw/single_event/likelihood.py
@@ -44,7 +44,6 @@ class TransientLikelihoodFD(SingleEventLikelihood):
         f_min: Float = 0,
         f_max: Float = float("inf"),
         trigger_time: Float = 0,
-        start_time: Float = -2,
         **kwargs,
     ) -> None:
         # NOTE: having 'kwargs' here makes it very difficult to diagnose
@@ -92,7 +91,7 @@ class TransientLikelihoodFD(SingleEventLikelihood):
 
         self.trigger_time = trigger_time
         self.duration = duration = self.detectors[0].data.duration
-        self.start_time = start_time
+        self.start_time = self.detectors[0].epoch
         self.kwargs = kwargs
         if "marginalization" in self.kwargs:
             marginalization = self.kwargs["marginalization"]
@@ -227,7 +226,6 @@ class HeterodynedTransientLikelihoodFD(TransientLikelihoodFD):
         f_max: Float = float("inf"),
         n_bins: int = 100,
         trigger_time: float = 0,
-        start_time: Float = -2,
         popsize: int = 100,
         n_steps: int = 2000,
         ref_params: dict = {},
@@ -238,7 +236,7 @@ class HeterodynedTransientLikelihoodFD(TransientLikelihoodFD):
         **kwargs,
     ) -> None:
         super().__init__(
-            detectors, waveform, f_min, f_max, trigger_time, start_time
+            detectors, waveform, f_min, f_max, trigger_time
         )
 
         logging.info("Initializing heterodyned likelihood..")

--- a/src/jimgw/single_event/likelihood.py
+++ b/src/jimgw/single_event/likelihood.py
@@ -2,6 +2,7 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 import numpy.typing as npt
+from collections import OrderedDict
 from flowMC.strategy.optimization import AdamOptimization
 from jax.scipy.special import logsumexp
 from jaxtyping import Array, Float
@@ -510,7 +511,7 @@ class HeterodynedTransientLikelihoodFD(TransientLikelihoodFD):
             for transform in sample_transforms:
                 guess = jax.vmap(transform.forward)(guess)
             guess = jnp.array(
-                jax.tree.leaves({key: guess[key] for key in parameter_names})
+                jax.tree.leaves(OrderedDict({key: guess[key] for key in parameter_names}))
             ).T
             finite_guess = jnp.where(
                 jnp.all(jax.tree.map(lambda x: jnp.isfinite(x), guess), axis=1)

--- a/src/jimgw/single_event/likelihood.py
+++ b/src/jimgw/single_event/likelihood.py
@@ -88,7 +88,7 @@ class TransientLikelihoodFD(SingleEventLikelihood):
 
         self.waveform = waveform
         self.gmst = (
-            Time(trigger_time, format="gps").sidereal_time("mean",
+            Time(trigger_time, format="gps").sidereal_time("apparent",
                                                            "greenwich").rad
         )
 

--- a/src/jimgw/single_event/likelihood.py
+++ b/src/jimgw/single_event/likelihood.py
@@ -93,7 +93,6 @@ class TransientLikelihoodFD(SingleEventLikelihood):
         self.trigger_time = trigger_time
         self.duration = duration = self.detectors[0].data.duration
         self.start_time = start_time
-        self.post_trigger_duration = start_time + duration - trigger_time
         self.kwargs = kwargs
         if "marginalization" in self.kwargs:
             marginalization = self.kwargs["marginalization"]
@@ -157,7 +156,10 @@ class TransientLikelihoodFD(SingleEventLikelihood):
     def epoch(self):
         """The epoch of the data.
         """
-        return self.duration - self.post_trigger_duration
+        # The previous definition was:
+        # post_trigger_duration = start_time + duration - trigger_time
+        # return duration - post_trigger_duration
+        return self.trigger_time - self.start_time
 
     @property
     def ifos(self):

--- a/src/jimgw/single_event/likelihood.py
+++ b/src/jimgw/single_event/likelihood.py
@@ -2,7 +2,6 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 import numpy.typing as npt
-from astropy.time import Time
 from flowMC.strategy.optimization import AdamOptimization
 from jax.scipy.special import logsumexp
 from jaxtyping import Array, Float
@@ -15,6 +14,7 @@ from jimgw.single_event.detector import Detector
 from jimgw.utils import log_i0
 from jimgw.single_event.waveform import Waveform
 from jimgw.transforms import BijectiveTransform, NtoMTransform
+from jimgw.gps_times import greenwich_mean_sidereal_time as jim_gmst
 import logging
 
 HR_TO_RAD = 2 * np.pi / 24
@@ -87,10 +87,7 @@ class TransientLikelihoodFD(SingleEventLikelihood):
         self.psds = psds
 
         self.waveform = waveform
-        self.gmst = (
-            Time(trigger_time, format="gps").sidereal_time("apparent",
-                                                           "greenwich").rad
-        )
+        self.gmst = jim_gmst(trigger_time)
 
         self.trigger_time = trigger_time
         self.duration = duration = self.detectors[0].data.duration
@@ -174,8 +171,6 @@ class TransientLikelihoodFD(SingleEventLikelihood):
         """Evaluate the likelihood for a given set of parameters.
         """
         frequencies = self.frequencies
-        # params["gmst"] = self.gmst
-        # Note: How about we sample in "geocent_time" instead?
         params["gmst"] = self.gmst + params["t_c"] / HR_TO_SEC * HR_TO_RAD
         # adjust the params due to different marginalzation scheme
         params = self.param_func(params)

--- a/src/jimgw/single_event/likelihood.py
+++ b/src/jimgw/single_event/likelihood.py
@@ -14,7 +14,6 @@ from jimgw.single_event.detector import Detector
 from jimgw.utils import log_i0
 from jimgw.single_event.waveform import Waveform
 from jimgw.transforms import BijectiveTransform, NtoMTransform
-from jimgw.gps_times import greenwich_mean_sidereal_time as jim_gmst
 import logging
 
 HR_TO_RAD = 2 * np.pi / 24
@@ -65,7 +64,6 @@ class TransientLikelihoodFD(SingleEventLikelihood):
         self.duration = self.detectors[0].data.duration
         self.waveform = waveform
         self.trigger_time = trigger_time
-        self.gmst = jim_gmst(trigger_time)
         self.kwargs = kwargs
         if "marginalization" in self.kwargs:
             marginalization = self.kwargs["marginalization"]
@@ -119,7 +117,7 @@ class TransientLikelihoodFD(SingleEventLikelihood):
     def evaluate(self, params: dict[str, Float], data: dict) -> Float:
         # TODO: Test whether we need to pass data in or with class changes is fine.
         """Evaluate the likelihood for a given set of parameters."""
-        params["gmst"] = self.gmst + params["t_c"] * SEC_TO_RAD
+        params["geocent_time"] = self.trigger_time + params["t_c"]
         # adjust the params due to different marginalzation scheme
         params = self.param_func(params)
         # adjust the params due to fixing parameters
@@ -257,7 +255,7 @@ class HeterodynedTransientLikelihoodFD(TransientLikelihoodFD):
 
         logging.info("Constructing reference waveforms..")
 
-        self.ref_params["gmst"] = self.gmst + self.ref_params["t_c"] * SEC_TO_RAD
+        self.ref_params["geocent_time"] = self.trigger_time + self.ref_params["t_c"]
         # adjust the params due to different marginalzation scheme
         self.ref_params = self.param_func(self.ref_params)
         # adjust the params due to fixing parameters
@@ -327,7 +325,7 @@ class HeterodynedTransientLikelihoodFD(TransientLikelihoodFD):
     def evaluate(self, params: dict[str, Float], data: dict) -> Float:
         frequencies_low = self.freq_grid_low
         frequencies_center = self.freq_grid_center
-        params["gmst"] = self.gmst + params["t_c"] * SEC_TO_RAD
+        params["geocent_time"] = self.trigger_time + params["t_c"]
         # adjust the params due to different marginalzation scheme
         params = self.param_func(params)
         # adjust the params due to fixing parameters
@@ -361,7 +359,7 @@ class HeterodynedTransientLikelihoodFD(TransientLikelihoodFD):
         """
         Evaluate the likelihood for a given set of parameters.
         """
-        params["gmst"] = self.gmst + params["t_c"] * SEC_TO_RAD
+        params["geocent_time"] = self.trigger_time + params["t_c"]
         # adjust the params due to different marginalzation scheme
         params = self.param_func(params)
         # adjust the params due to fixing parameters

--- a/src/jimgw/single_event/likelihood.py
+++ b/src/jimgw/single_event/likelihood.py
@@ -721,9 +721,7 @@ def original_relative_binning_likelihood(
     log_likelihood = 0.0
 
     for detector in detectors:
-        waveform_low = detector.fd_response(
-            frequencies_low, waveform_sky_low, params
-        )
+        waveform_low = detector.fd_response(frequencies_low, waveform_sky_low, params)
         waveform_center = detector.fd_response(
             frequencies_low, waveform_sky_center, params
         )
@@ -763,9 +761,7 @@ def phase_marginalized_relative_binning_likelihood(
     complex_d_inner_h = 0.0
 
     for detector in detectors:
-        waveform_low = detector.fd_response(
-            frequencies_low, waveform_sky_low, params
-        )
+        waveform_low = detector.fd_response(frequencies_low, waveform_sky_low, params)
         waveform_center = detector.fd_response(
             frequencies_center, waveform_sky_center, params
         )

--- a/src/jimgw/single_event/likelihood.py
+++ b/src/jimgw/single_event/likelihood.py
@@ -19,6 +19,7 @@ import logging
 
 HR_TO_RAD = 2 * np.pi / 24
 HR_TO_SEC = 3600
+SEC_TO_RAD = HR_TO_RAD / HR_TO_SEC
 
 
 class SingleEventLikelihood(LikelihoodBase):
@@ -118,7 +119,7 @@ class TransientLikelihoodFD(SingleEventLikelihood):
     def evaluate(self, params: dict[str, Float], data: dict) -> Float:
         # TODO: Test whether we need to pass data in or with class changes is fine.
         """Evaluate the likelihood for a given set of parameters."""
-        params["gmst"] = self.gmst + params["t_c"] / HR_TO_SEC * HR_TO_RAD
+        params["gmst"] = self.gmst + params["t_c"] * SEC_TO_RAD
         # adjust the params due to different marginalzation scheme
         params = self.param_func(params)
         # adjust the params due to fixing parameters
@@ -256,7 +257,7 @@ class HeterodynedTransientLikelihoodFD(TransientLikelihoodFD):
 
         logging.info("Constructing reference waveforms..")
 
-        self.ref_params["gmst"] = self.gmst
+        self.ref_params["gmst"] = self.gmst + self.ref_params["t_c"] * SEC_TO_RAD
         # adjust the params due to different marginalzation scheme
         self.ref_params = self.param_func(self.ref_params)
         # adjust the params due to fixing parameters
@@ -326,7 +327,7 @@ class HeterodynedTransientLikelihoodFD(TransientLikelihoodFD):
     def evaluate(self, params: dict[str, Float], data: dict) -> Float:
         frequencies_low = self.freq_grid_low
         frequencies_center = self.freq_grid_center
-        params["gmst"] = self.gmst
+        params["gmst"] = self.gmst + params["t_c"] * SEC_TO_RAD
         # adjust the params due to different marginalzation scheme
         params = self.param_func(params)
         # adjust the params due to fixing parameters
@@ -360,7 +361,7 @@ class HeterodynedTransientLikelihoodFD(TransientLikelihoodFD):
         """
         Evaluate the likelihood for a given set of parameters.
         """
-        params["gmst"] = self.gmst
+        params["gmst"] = self.gmst + params["t_c"] * SEC_TO_RAD
         # adjust the params due to different marginalzation scheme
         params = self.param_func(params)
         # adjust the params due to fixing parameters

--- a/src/jimgw/single_event/likelihood.py
+++ b/src/jimgw/single_event/likelihood.py
@@ -14,6 +14,7 @@ from jimgw.single_event.detector import Detector
 from jimgw.utils import log_i0
 from jimgw.single_event.waveform import Waveform
 from jimgw.transforms import BijectiveTransform, NtoMTransform
+from jimgw.gps_times import greenwich_mean_sidereal_time as compute_gmst
 import logging
 
 HR_TO_RAD = 2 * np.pi / 24
@@ -67,6 +68,7 @@ class TransientLikelihoodFD(SingleEventLikelihood):
         self.duration = self.detectors[0].data.duration
         self.waveform = waveform
         self.trigger_time = trigger_time
+        self.gmst = compute_gmst(self.trigger_time)
         self.kwargs = kwargs
         if "marginalization" in self.kwargs:
             marginalization = self.kwargs["marginalization"]
@@ -120,7 +122,8 @@ class TransientLikelihoodFD(SingleEventLikelihood):
     def evaluate(self, params: dict[str, Float], data: dict) -> Float:
         # TODO: Test whether we need to pass data in or with class changes is fine.
         """Evaluate the likelihood for a given set of parameters."""
-        params["geocent_time"] = self.trigger_time + params["t_c"]
+        params["trigger_time"] = self.trigger_time
+        params["gmst"] = self.gmst
         # adjust the params due to different marginalzation scheme
         params = self.param_func(params)
         # adjust the params due to fixing parameters
@@ -259,7 +262,8 @@ class HeterodynedTransientLikelihoodFD(TransientLikelihoodFD):
 
         logging.info("Constructing reference waveforms..")
 
-        self.ref_params["geocent_time"] = self.trigger_time + self.ref_params["t_c"]
+        self.ref_params["trigger_time"] = self.trigger_time
+        self.ref_params["gmst"] = self.gmst
         # adjust the params due to different marginalzation scheme
         self.ref_params = self.param_func(self.ref_params)
         # adjust the params due to fixing parameters
@@ -329,7 +333,8 @@ class HeterodynedTransientLikelihoodFD(TransientLikelihoodFD):
     def evaluate(self, params: dict[str, Float], data: dict) -> Float:
         frequencies_low = self.freq_grid_low
         frequencies_center = self.freq_grid_center
-        params["geocent_time"] = self.trigger_time + params["t_c"]
+        params["trigger_time"] = self.trigger_time
+        params["gmst"] = self.gmst
         # adjust the params due to different marginalzation scheme
         params = self.param_func(params)
         # adjust the params due to fixing parameters
@@ -362,7 +367,8 @@ class HeterodynedTransientLikelihoodFD(TransientLikelihoodFD):
         """
         Evaluate the likelihood for a given set of parameters.
         """
-        params["geocent_time"] = self.trigger_time + params["t_c"]
+        params["trigger_time"] = self.trigger_time
+        params["gmst"] = self.gmst
         # adjust the params due to different marginalzation scheme
         params = self.param_func(params)
         # adjust the params due to fixing parameters

--- a/src/jimgw/single_event/likelihood.py
+++ b/src/jimgw/single_event/likelihood.py
@@ -171,7 +171,10 @@ class TransientLikelihoodFD(SingleEventLikelihood):
         """Evaluate the likelihood for a given set of parameters.
         """
         frequencies = self.frequencies
-        params["gmst"] = self.gmst
+        # params["gmst"] = self.gmst
+        # Note: How about we sample in "geocent_time" instead?
+        _gmst = Time(self.trigger_time + params["t_c"], format="gps")
+        params["gmst"] = _gmst.sidereal_time("apparent", "greenwich").rad
         # adjust the params due to different marginalzation scheme
         params = self.param_func(params)
         # adjust the params due to fixing parameters

--- a/src/jimgw/single_event/likelihood.py
+++ b/src/jimgw/single_event/likelihood.py
@@ -17,6 +17,9 @@ from jimgw.single_event.waveform import Waveform
 from jimgw.transforms import BijectiveTransform, NtoMTransform
 import logging
 
+HR_TO_RAD = 2 * np.pi / 24
+HR_TO_SEC = 3600
+
 
 class SingleEventLikelihood(LikelihoodBase):
     detectors: list[Detector]
@@ -85,7 +88,7 @@ class TransientLikelihoodFD(SingleEventLikelihood):
 
         self.waveform = waveform
         self.gmst = (
-            Time(trigger_time, format="gps").sidereal_time("apparent",
+            Time(trigger_time, format="gps").sidereal_time("mean",
                                                            "greenwich").rad
         )
 
@@ -173,8 +176,7 @@ class TransientLikelihoodFD(SingleEventLikelihood):
         frequencies = self.frequencies
         # params["gmst"] = self.gmst
         # Note: How about we sample in "geocent_time" instead?
-        _gmst = Time(self.trigger_time + params["t_c"], format="gps")
-        params["gmst"] = _gmst.sidereal_time("apparent", "greenwich").rad
+        params["gmst"] = self.gmst + params["t_c"] / HR_TO_SEC * HR_TO_RAD
         # adjust the params due to different marginalzation scheme
         params = self.param_func(params)
         # adjust the params due to fixing parameters

--- a/src/jimgw/single_event/likelihood.py
+++ b/src/jimgw/single_event/likelihood.py
@@ -17,7 +17,7 @@ from jimgw.transforms import BijectiveTransform, NtoMTransform
 from jimgw.gps_times import greenwich_mean_sidereal_time as compute_gmst
 import logging
 
-HR_TO_RAD = 2 * np.pi / 24
+HR_TO_RAD = 2 * jnp.pi / 24
 HR_TO_SEC = 3600
 SEC_TO_RAD = HR_TO_RAD / HR_TO_SEC
 

--- a/src/jimgw/single_event/likelihood.py
+++ b/src/jimgw/single_event/likelihood.py
@@ -131,7 +131,6 @@ class TransientLikelihoodFD(SingleEventLikelihood):
             params,
             waveform_sky,
             self.detectors,
-            self.trigger_time,
             **self.kwargs,
         )
 
@@ -305,13 +304,13 @@ class HeterodynedTransientLikelihoodFD(TransientLikelihoodFD):
         for detector in self.detectors:
             # Get the reference waveforms
             waveform_ref = detector.fd_response(
-                frequency_original, h_sky, self.ref_params, trigger_time
+                frequency_original, h_sky, self.ref_params
             )
             self.waveform_low_ref[detector.name] = detector.fd_response(
-                self.freq_grid_low, h_sky_low, self.ref_params, trigger_time
+                self.freq_grid_low, h_sky_low, self.ref_params
             )
             self.waveform_center_ref[detector.name] = detector.fd_response(
-                self.freq_grid_center, h_sky_center, self.ref_params, trigger_time
+                self.freq_grid_center, h_sky_center, self.ref_params
             )
             A0, A1, B0, B1 = self.compute_coefficients(
                 detector.fd_data_slice,
@@ -351,7 +350,6 @@ class HeterodynedTransientLikelihoodFD(TransientLikelihoodFD):
             self.detectors,
             frequencies_low,
             frequencies_center,
-            self.trigger_time,
             **self.kwargs,
         )
         return log_likelihood
@@ -375,7 +373,6 @@ class HeterodynedTransientLikelihoodFD(TransientLikelihoodFD):
             params,
             waveform_sky,
             self.detectors,
-            self.trigger_time,
             **self.kwargs,
         )
 
@@ -560,13 +557,12 @@ def original_likelihood(
     params: dict[str, Float],
     h_sky: dict[str, Float[Array, " n_dim"]],
     detectors: list[Detector],
-    trigger_time: Float,
     **kwargs,
 ) -> Float:
     log_likelihood = 0.0
     for ifo in detectors:
         freqs, data, psd = ifo.sliced_frequencies, ifo.fd_data_slice, ifo.psd_slice
-        h_dec = ifo.fd_response(freqs, h_sky, params, trigger_time)
+        h_dec = ifo.fd_response(freqs, h_sky, params)
         match_filter_SNR = inner_product(h_dec, data, psd, freqs).real
         optimal_SNR = inner_product(h_dec, h_dec, psd, freqs).real
         log_likelihood += match_filter_SNR - optimal_SNR / 2
@@ -578,14 +574,13 @@ def phase_marginalized_likelihood(
     params: dict[str, Float],
     h_sky: dict[str, Float[Array, " n_dim"]],
     detectors: list[Detector],
-    trigger_time: Float,
     **kwargs,
 ) -> Float:
     log_likelihood = 0.0
     complex_d_inner_h = 0.0 + 0.0j
     for ifo in detectors:
         freqs, data, psd = ifo.sliced_frequencies, ifo.fd_data_slice, ifo.psd_slice
-        h_dec = ifo.fd_response(freqs, h_sky, params, trigger_time)
+        h_dec = ifo.fd_response(freqs, h_sky, params)
         complex_d_inner_h += inner_product(h_dec, data, psd, freqs)
         optimal_SNR = inner_product(h_dec, h_dec, psd, freqs).real
         log_likelihood += -optimal_SNR / 2
@@ -617,14 +612,13 @@ def time_marginalized_likelihood(
     params: dict[str, Float],
     h_sky: dict[str, Float[Array, " n_dim"]],
     detectors: list[Detector],
-    trigger_time: Float,
     **kwargs,
 ) -> Float:
     log_likelihood = 0.0
     complex_h_inner_d = 0.0 + 0.0j
     for ifo in detectors:
         freqs, data, psd = ifo.sliced_frequencies, ifo.fd_data_slice, ifo.psd_slice
-        h_dec = ifo.fd_response(freqs, h_sky, params, trigger_time)
+        h_dec = ifo.fd_response(freqs, h_sky, params)
         # using <h|d> instead of <d|h>
         complex_h_inner_d += inner_product(data, h_dec, psd, freqs)
         optimal_SNR = inner_product(h_dec, h_dec, psd, freqs).real
@@ -665,14 +659,13 @@ def phase_time_marginalized_likelihood(
     params: dict[str, Float],
     h_sky: dict[str, Float[Array, " n_dim"]],
     detectors: list[Detector],
-    trigger_time: Float,
     **kwargs,
 ) -> Float:
     log_likelihood = 0.0
     complex_h_inner_d = 0.0 + 0.0j
     for ifo in detectors:
         freqs, data, psd = ifo.sliced_frequencies, ifo.fd_data_slice, ifo.psd_slice
-        h_dec = ifo.fd_response(freqs, h_sky, params, trigger_time)
+        h_dec = ifo.fd_response(freqs, h_sky, params)
         # using <h|d> instead of <d|h>
         complex_h_inner_d += inner_product(data, h_dec, psd, freqs)
         optimal_SNR = inner_product(h_dec, h_dec, psd, freqs).real
@@ -722,7 +715,6 @@ def original_relative_binning_likelihood(
     detectors,
     frequencies_low,
     frequencies_center,
-    trigger_time,
     **kwargs,
 ):
 
@@ -730,10 +722,10 @@ def original_relative_binning_likelihood(
 
     for detector in detectors:
         waveform_low = detector.fd_response(
-            frequencies_low, waveform_sky_low, params, trigger_time
+            frequencies_low, waveform_sky_low, params
         )
         waveform_center = detector.fd_response(
-            frequencies_low, waveform_sky_center, params, trigger_time
+            frequencies_low, waveform_sky_center, params
         )
 
         r0 = waveform_center / waveform_center_ref[detector.name]
@@ -765,7 +757,6 @@ def phase_marginalized_relative_binning_likelihood(
     detectors,
     frequencies_low,
     frequencies_center,
-    trigger_time,
     **kwargs,
 ):
     log_likelihood = 0.0
@@ -773,10 +764,10 @@ def phase_marginalized_relative_binning_likelihood(
 
     for detector in detectors:
         waveform_low = detector.fd_response(
-            frequencies_low, waveform_sky_low, params, trigger_time
+            frequencies_low, waveform_sky_low, params
         )
         waveform_center = detector.fd_response(
-            frequencies_center, waveform_sky_center, params, trigger_time
+            frequencies_center, waveform_sky_center, params
         )
 
         r0 = waveform_center / waveform_center_ref[detector.name]

--- a/src/jimgw/single_event/transforms.py
+++ b/src/jimgw/single_event/transforms.py
@@ -404,7 +404,7 @@ class DistanceToSNRWeightedDistanceTransform(ConditionalBijectiveTransform):
                 antenna_pattern = ifo.antenna_pattern(ra, dec, psi, self.gmst)
                 p_mode_term = p_iota_term * antenna_pattern["p"]
                 c_mode_term = c_iota_term * antenna_pattern["c"]
-                R_dets2 += p_mode_term ** 2 + c_mode_term ** 2
+                R_dets2 += p_mode_term**2 + c_mode_term**2
 
             return np.sqrt(R_dets2)
 

--- a/src/jimgw/single_event/transforms.py
+++ b/src/jimgw/single_event/transforms.py
@@ -1,4 +1,4 @@
-import jax.numpy as np
+import jax.numpy as jnp
 from beartype import beartype as typechecker
 from jaxtyping import Float, Array, jaxtyped
 
@@ -25,7 +25,7 @@ from jimgw.single_event.utils import (
 from jimgw.gps_times import greenwich_mean_sidereal_time as compute_gmst
 
 # Move these to constants.
-HR_TO_RAD = 2 * np.pi / 24
+HR_TO_RAD = 2 * jnp.pi / 24
 HR_TO_SEC = 3600
 SEC_TO_RAD = HR_TO_RAD / HR_TO_SEC
 
@@ -131,9 +131,9 @@ class SphereSpinToCartesianSpinTransform(BijectiveTransform):
 
         def named_transform(x):
             mag, theta, phi = x[label + "_mag"], x[label + "_theta"], x[label + "_phi"]
-            x = mag * np.sin(theta) * np.cos(phi)
-            y = mag * np.sin(theta) * np.sin(phi)
-            z = mag * np.cos(theta)
+            x = mag * jnp.sin(theta) * jnp.cos(phi)
+            y = mag * jnp.sin(theta) * jnp.sin(phi)
+            z = mag * jnp.cos(theta)
             return {
                 label + "_x": x,
                 label + "_y": y,
@@ -142,9 +142,9 @@ class SphereSpinToCartesianSpinTransform(BijectiveTransform):
 
         def named_inverse_transform(x):
             x, y, z = x[label + "_x"], x[label + "_y"], x[label + "_z"]
-            mag = np.sqrt(x**2 + y**2 + z**2)
+            mag = jnp.sqrt(x**2 + y**2 + z**2)
             theta, phi = carte_to_spherical_angles(x, y, z)
-            phi = np.mod(phi, 2.0 * np.pi)
+            phi = jnp.mod(phi, 2.0 * jnp.pi)
 
             return {
                 label + "_mag": mag,
@@ -177,7 +177,7 @@ class SkyFrameToDetectorFrameSkyPositionTransform(BijectiveTransform):
         self.gmst = compute_gmst(gps_time)
         delta_x = ifos[0].vertex - ifos[1].vertex
         self.rotation = euler_rotation(delta_x)
-        self.rotation_inv = np.linalg.inv(self.rotation)
+        self.rotation_inv = jnp.linalg.inv(self.rotation)
 
         def named_transform(x):
             zenith, azimuth = ra_dec_to_zenith_azimuth(
@@ -251,7 +251,7 @@ class GeocentricArrivalTimeToDetectorArrivalTimeTransform(
             t_det_max = self.tc_max + time_shift
 
             y = (t_det - t_det_min) / (t_det_max - t_det_min)
-            t_det_unbounded = np.log(y / (1.0 - y))
+            t_det_unbounded = jnp.log(y / (1.0 - y))
             return {
                 "t_det_unbounded": t_det_unbounded,
             }
@@ -264,7 +264,7 @@ class GeocentricArrivalTimeToDetectorArrivalTimeTransform(
             t_det_min = self.tc_min + time_shift
             t_det_max = self.tc_max + time_shift
             t_det = (t_det_max - t_det_min) / (
-                1.0 + np.exp(-x["t_det_unbounded"])
+                1.0 + jnp.exp(-x["t_det_unbounded"])
             ) + t_det_min
 
             t_c = t_det - time_shift
@@ -320,14 +320,14 @@ class GeocentricArrivalPhaseToDetectorArrivalPhaseTransform(
         )
 
         def _calc_R_det_arg(ra, dec, psi, iota, gmst):
-            p_iota_term = (1.0 + np.cos(iota) ** 2) / 2.0
-            c_iota_term = np.cos(iota)
+            p_iota_term = (1.0 + jnp.cos(iota) ** 2) / 2.0
+            c_iota_term = jnp.cos(iota)
 
             antenna_pattern = self.ifo.antenna_pattern(ra, dec, psi, gmst)
             p_mode_term = p_iota_term * antenna_pattern["p"]
             c_mode_term = c_iota_term * antenna_pattern["c"]
 
-            return np.angle(p_mode_term - 1j * c_mode_term)
+            return jnp.angle(p_mode_term - 1j * c_mode_term)
 
         def named_transform(x):
             R_det_arg = _calc_R_det_arg(
@@ -335,7 +335,7 @@ class GeocentricArrivalPhaseToDetectorArrivalPhaseTransform(
             )
             phase_det = R_det_arg + x["phase_c"] / 2.0
             return {
-                "phase_det": phase_det % (2.0 * np.pi),
+                "phase_det": phase_det % (2.0 * jnp.pi),
             }
 
         self.transform_func = named_transform
@@ -346,7 +346,7 @@ class GeocentricArrivalPhaseToDetectorArrivalPhaseTransform(
             )
             phase_c = -R_det_arg + x["phase_det"] * 2.0
             return {
-                "phase_c": phase_c % (2.0 * np.pi),
+                "phase_c": phase_c % (2.0 * jnp.pi),
             }
 
         self.inverse_transform_func = named_inverse_transform
@@ -395,8 +395,8 @@ class DistanceToSNRWeightedDistanceTransform(ConditionalBijectiveTransform):
         )
 
         def _calc_R_dets(ra, dec, psi, iota):
-            p_iota_term = (1.0 + np.cos(iota) ** 2) / 2.0
-            c_iota_term = np.cos(iota)
+            p_iota_term = (1.0 + jnp.cos(iota) ** 2) / 2.0
+            c_iota_term = jnp.cos(iota)
             R_dets2 = 0.0
 
             for ifo in self.ifos:
@@ -405,7 +405,7 @@ class DistanceToSNRWeightedDistanceTransform(ConditionalBijectiveTransform):
                 c_mode_term = c_iota_term * antenna_pattern["c"]
                 R_dets2 += p_mode_term**2 + c_mode_term**2
 
-            return np.sqrt(R_dets2)
+            return jnp.sqrt(R_dets2)
 
         def named_transform(x):
             d_L, M_c = (
@@ -414,14 +414,14 @@ class DistanceToSNRWeightedDistanceTransform(ConditionalBijectiveTransform):
             )
             R_dets = _calc_R_dets(x["ra"], x["dec"], x["psi"], x["iota"])
 
-            scale_factor = 1.0 / np.power(M_c, 5.0 / 6.0) / R_dets
+            scale_factor = 1.0 / jnp.power(M_c, 5.0 / 6.0) / R_dets
             d_hat = scale_factor * d_L
 
             d_hat_min = scale_factor * self.dL_min
             d_hat_max = scale_factor * self.dL_max
 
             y = (d_hat - d_hat_min) / (d_hat_max - d_hat_min)
-            d_hat_unbounded = np.log(y / (1.0 - y))
+            d_hat_unbounded = jnp.log(y / (1.0 - y))
 
             return {
                 "d_hat_unbounded": d_hat_unbounded,
@@ -436,13 +436,13 @@ class DistanceToSNRWeightedDistanceTransform(ConditionalBijectiveTransform):
             )
             R_dets = _calc_R_dets(x["ra"], x["dec"], x["psi"], x["iota"])
 
-            scale_factor = 1.0 / np.power(M_c, 5.0 / 6.0) / R_dets
+            scale_factor = 1.0 / jnp.power(M_c, 5.0 / 6.0) / R_dets
 
             d_hat_min = scale_factor * self.dL_min
             d_hat_max = scale_factor * self.dL_max
 
             d_hat = (d_hat_max - d_hat_min) / (
-                1.0 + np.exp(-d_hat_unbounded)
+                1.0 + jnp.exp(-d_hat_unbounded)
             ) + d_hat_min
             d_L = d_hat / scale_factor
             return {

--- a/src/jimgw/single_event/transforms.py
+++ b/src/jimgw/single_event/transforms.py
@@ -142,9 +142,9 @@ class SphereSpinToCartesianSpinTransform(BijectiveTransform):
 
         def named_inverse_transform(x):
             x, y, z = x[label + "_x"], x[label + "_y"], x[label + "_z"]
-            mag = jnp.sqrt(x**2 + y**2 + z**2)
+            mag = np.sqrt(x**2 + y**2 + z**2)
             theta, phi = carte_to_spherical_angles(x, y, z)
-            phi = jnp.mod(phi, 2.0 * jnp.pi)
+            phi = np.mod(phi, 2.0 * np.pi)
 
             return {
                 label + "_mag": mag,

--- a/src/jimgw/single_event/transforms.py
+++ b/src/jimgw/single_event/transforms.py
@@ -22,7 +22,7 @@ from jimgw.single_event.utils import (
     cartesian_spin_to_spin_angles,
     carte_to_spherical_angles,
 )
-from jimgw.gps_times import greenwich_mean_sidereal_time as jim_gmst
+from jimgw.gps_times import greenwich_mean_sidereal_time as compute_gmst
 
 # Move these to constants.
 HR_TO_RAD = 2 * np.pi / 24
@@ -173,7 +173,7 @@ class SkyFrameToDetectorFrameSkyPositionTransform(BijectiveTransform):
         name_mapping = (["ra", "dec"], ["zenith", "azimuth"])
         super().__init__(name_mapping)
 
-        self.gmst = jim_gmst(gps_time)
+        self.gmst = compute_gmst(gps_time)
         delta_x = ifos[0].vertex - ifos[1].vertex
         self.rotation = euler_rotation(delta_x)
         self.rotation_inv = np.linalg.inv(self.rotation)
@@ -231,7 +231,7 @@ class GeocentricArrivalTimeToDetectorArrivalTimeTransform(
         conditional_names = ["ra", "dec"]
         super().__init__(name_mapping, conditional_names)
 
-        self.gmst = jim_gmst(gps_time)
+        self.gmst = compute_gmst(gps_time)
         self.ifo = ifo
         self.tc_min = tc_min
         self.tc_max = tc_max
@@ -308,7 +308,7 @@ class GeocentricArrivalPhaseToDetectorArrivalPhaseTransform(
         conditional_names = ["ra", "dec", "psi", "iota"]
         super().__init__(name_mapping, conditional_names)
 
-        self.gmst = jim_gmst(gps_time)
+        self.gmst = compute_gmst(gps_time)
         self.ifo = ifo
 
         assert "phase_c" in name_mapping[0] and "phase_det" in name_mapping[1]
@@ -380,7 +380,7 @@ class DistanceToSNRWeightedDistanceTransform(ConditionalBijectiveTransform):
         conditional_names = ["M_c", "ra", "dec", "psi", "iota"]
         super().__init__(name_mapping, conditional_names)
 
-        self.gmst = jim_gmst(gps_time)
+        self.gmst = compute_gmst(gps_time)
         self.ifos = ifos
         self.dL_min = dL_min
         self.dL_max = dL_max

--- a/src/jimgw/single_event/transforms.py
+++ b/src/jimgw/single_event/transforms.py
@@ -243,7 +243,6 @@ class GeocentricArrivalTimeToDetectorArrivalTimeTransform(
         def time_delay(ra, dec, gmst):
             return self.ifo.delay_from_geocenter(ra, dec, gmst)
 
-        # TODO: Need to check whether time_delay needs t_c input
         def named_transform(x):
             time_shift = time_delay(x["ra"], x["dec"], self.gmst)
 

--- a/src/jimgw/single_event/transforms.py
+++ b/src/jimgw/single_event/transforms.py
@@ -1,7 +1,6 @@
 import jax.numpy as jnp
 from beartype import beartype as typechecker
 from jaxtyping import Float, Array, jaxtyped
-from astropy.time import Time
 
 from jimgw.single_event.detector import GroundBased2G
 from jimgw.transforms import (
@@ -22,6 +21,7 @@ from jimgw.single_event.utils import (
     spin_angles_to_cartesian_spin,
     cartesian_spin_to_spin_angles,
 )
+from jimgw.gps_times import greenwich_mean_sidereal_time as jim_gmst
 
 
 @jaxtyped(typechecker=typechecker)
@@ -161,9 +161,7 @@ class SkyFrameToDetectorFrameSkyPositionTransform(BijectiveTransform):
         name_mapping = (["ra", "dec"], ["zenith", "azimuth"])
         super().__init__(name_mapping)
 
-        self.gmst = (
-            Time(gps_time, format="gps").sidereal_time("apparent", "greenwich").rad
-        )
+        self.gmst = jim_gmst(gps_time)
         delta_x = ifos[0].vertex - ifos[1].vertex
         self.rotation = euler_rotation(delta_x)
         self.rotation_inv = jnp.linalg.inv(self.rotation)
@@ -221,9 +219,7 @@ class GeocentricArrivalTimeToDetectorArrivalTimeTransform(
         conditional_names = ["ra", "dec"]
         super().__init__(name_mapping, conditional_names)
 
-        self.gmst = (
-            Time(gps_time, format="gps").sidereal_time("apparent", "greenwich").rad
-        )
+        self.gmst = jim_gmst(gps_time)
         self.ifo = ifo
         self.tc_min = tc_min
         self.tc_max = tc_max
@@ -299,9 +295,7 @@ class GeocentricArrivalPhaseToDetectorArrivalPhaseTransform(
         conditional_names = ["ra", "dec", "psi", "iota"]
         super().__init__(name_mapping, conditional_names)
 
-        self.gmst = (
-            Time(gps_time, format="gps").sidereal_time("apparent", "greenwich").rad
-        )
+        self.gmst = jim_gmst(gps_time)
         self.ifo = ifo
 
         assert "phase_c" in name_mapping[0] and "phase_det" in name_mapping[1]
@@ -373,9 +367,7 @@ class DistanceToSNRWeightedDistanceTransform(ConditionalBijectiveTransform):
         conditional_names = ["M_c", "ra", "dec", "psi", "iota"]
         super().__init__(name_mapping, conditional_names)
 
-        self.gmst = (
-            Time(gps_time, format="gps").sidereal_time("apparent", "greenwich").rad
-        )
+        self.gmst = jim_gmst(gps_time)
         self.ifos = ifos
         self.dL_min = dL_min
         self.dL_max = dL_max

--- a/src/jimgw/transforms.py
+++ b/src/jimgw/transforms.py
@@ -86,7 +86,6 @@ class NtoNTransform(NtoMTransform):
         transform_params = dict((key, x_copy[key]) for key in self.name_mapping[0])
         output_params = self.transform_func(transform_params)
         jacobian = jax.jacfwd(self.transform_func)(transform_params)
-        # No need to use OrderedDict for determinant
         jacobian = jnp.array(jax.tree.leaves(jacobian))
         jacobian = jnp.log(
             jnp.absolute(jnp.linalg.det(jacobian.reshape(self.n_dim, self.n_dim)))
@@ -126,7 +125,6 @@ class BijectiveTransform(NtoNTransform):
         transform_params = dict((key, y_copy[key]) for key in self.name_mapping[1])
         output_params = self.inverse_transform_func(transform_params)
         jacobian = jax.jacfwd(self.inverse_transform_func)(transform_params)
-        # No need to use OrderedDict for determinant
         jacobian = jnp.array(jax.tree.leaves(jacobian))
         jacobian = jnp.log(
             jnp.absolute(jnp.linalg.det(jacobian.reshape(self.n_dim, self.n_dim)))
@@ -192,7 +190,6 @@ class ConditionalBijectiveTransform(BijectiveTransform):
             key1: {key2: jacobian[key1][key2] for key2 in self.name_mapping[0]}
             for key1 in self.name_mapping[1]
         }
-        # No need to use OrderedDict for determinant
         jacobian = jnp.array(jax.tree.leaves(jacobian_copy))
         jacobian = jnp.log(
             jnp.absolute(jnp.linalg.det(jacobian.reshape(self.n_dim, self.n_dim)))
@@ -219,7 +216,6 @@ class ConditionalBijectiveTransform(BijectiveTransform):
             key1: {key2: jacobian[key1][key2] for key2 in self.name_mapping[1]}
             for key1 in self.name_mapping[0]
         }
-        # No need to use OrderedDict for determinant
         jacobian = jnp.array(jax.tree.leaves(jacobian_copy))
         jacobian = jnp.log(
             jnp.absolute(jnp.linalg.det(jacobian.reshape(self.n_dim, self.n_dim)))

--- a/src/jimgw/transforms.py
+++ b/src/jimgw/transforms.py
@@ -86,6 +86,7 @@ class NtoNTransform(NtoMTransform):
         transform_params = dict((key, x_copy[key]) for key in self.name_mapping[0])
         output_params = self.transform_func(transform_params)
         jacobian = jax.jacfwd(self.transform_func)(transform_params)
+        # No need to use OrderedDict for determinant
         jacobian = jnp.array(jax.tree.leaves(jacobian))
         jacobian = jnp.log(
             jnp.absolute(jnp.linalg.det(jacobian.reshape(self.n_dim, self.n_dim)))
@@ -125,6 +126,7 @@ class BijectiveTransform(NtoNTransform):
         transform_params = dict((key, y_copy[key]) for key in self.name_mapping[1])
         output_params = self.inverse_transform_func(transform_params)
         jacobian = jax.jacfwd(self.inverse_transform_func)(transform_params)
+        # No need to use OrderedDict for determinant
         jacobian = jnp.array(jax.tree.leaves(jacobian))
         jacobian = jnp.log(
             jnp.absolute(jnp.linalg.det(jacobian.reshape(self.n_dim, self.n_dim)))
@@ -190,6 +192,7 @@ class ConditionalBijectiveTransform(BijectiveTransform):
             key1: {key2: jacobian[key1][key2] for key2 in self.name_mapping[0]}
             for key1 in self.name_mapping[1]
         }
+        # No need to use OrderedDict for determinant
         jacobian = jnp.array(jax.tree.leaves(jacobian_copy))
         jacobian = jnp.log(
             jnp.absolute(jnp.linalg.det(jacobian.reshape(self.n_dim, self.n_dim)))
@@ -216,6 +219,7 @@ class ConditionalBijectiveTransform(BijectiveTransform):
             key1: {key2: jacobian[key1][key2] for key2 in self.name_mapping[1]}
             for key1 in self.name_mapping[0]
         }
+        # No need to use OrderedDict for determinant
         jacobian = jnp.array(jax.tree.leaves(jacobian_copy))
         jacobian = jnp.log(
             jnp.absolute(jnp.linalg.det(jacobian.reshape(self.n_dim, self.n_dim)))

--- a/test/unit/test_sky_position_transform.ipynb
+++ b/test/unit/test_sky_position_transform.ipynb
@@ -6,6 +6,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import os\n",
+    "os.environ[\"JAX_PLATFORMS\"] = \"cpu\"\n",
     "import jax\n",
     "import jax.numpy as jnp\n",
     "\n",
@@ -33,18 +35,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Mean difference in RA:  [0.]\n",
-      "Mean difference in DEC:  [0.]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# test theta_phi_to_ra_dec in inverse transform\n",
     "from jimgw.single_event.utils import theta_phi_to_ra_dec as jim_theta_phi_to_ra_dec\n",
@@ -92,18 +85,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Mean difference in theta:  9.105216580707065e-17\n",
-      "Mean difference in phi:  5.018208071305708e-17\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# test angle rotation\n",
     "from jimgw.single_event.utils import angle_rotation as jim_angle_rotation\n",
@@ -158,19 +142,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Difference in delta_x for ('H1', 'L1'): [1.86264515e-09 4.65661287e-10 0.00000000e+00]\n",
-      "Difference in delta_x for ('H1', 'V1'): [1.86264515e-09 9.31322575e-10 9.31322575e-10]\n",
-      "Difference in delta_x for ('L1', 'V1'): [0.00000000e+00 0.00000000e+00 9.31322575e-10]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# test delta_x\n",
     "from itertools import combinations\n",
@@ -197,32 +171,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Mean difference in GMST:  1.0527752479539537e-05\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
+    "# Compare the greenwich mean sidereal time (GMST) and greenwich apparent sidereal time (GAST).\n",
+    "\n",
     "from bilby_cython.time import greenwich_mean_sidereal_time\n",
     "from astropy.time import Time\n",
     "\n",
-    "tol_diff = 0\n",
+    "tol_diff_1 = 0\n",
+    "tol_diff_2 = 0\n",
     "for time in np.random.uniform(1, 10000000, N_SAMPLES):\n",
-    "    gmst_j = Time(time, format=\"gps\").sidereal_time(\"apparent\", \"greenwich\").rad % (\n",
-    "        2 * np.pi\n",
-    "    )\n",
+    "    gps_time = Time(time, format=\"gps\")\n",
+    "    gmst_j = gps_time.sidereal_time(\"mean\", \"greenwich\").rad % (2 * np.pi)\n",
+    "    gast_j = gps_time.sidereal_time(\"apparent\", \"greenwich\").rad % (2 * np.pi)\n",
     "    gmst_b = greenwich_mean_sidereal_time(time) % (2 * np.pi)\n",
-    "    diff = jnp.abs(gmst_j - gmst_b)\n",
-    "    tol_diff += diff\n",
+    "    tol_diff_1 += jnp.abs(gmst_j - gmst_b)\n",
+    "    tol_diff_2 += jnp.abs(gast_j - gmst_b)\n",
     "\n",
-    "mean_diff = tol_diff / N_SAMPLES\n",
-    "print(\"Mean difference in GMST: \", mean_diff)"
+    "mean_diff = tol_diff_1 / N_SAMPLES\n",
+    "print(\"Mean difference in GMST: \", mean_diff)\n",
+    "mean_diff = tol_diff_2 / N_SAMPLES\n",
+    "print(\"Mean difference in GAST: \", mean_diff)"
    ]
   },
   {
@@ -234,18 +205,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Mean difference in RA:  [2.12414451e-05]\n",
-      "Mean difference in DEC:  [4.58300065e-16]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# test the transform\n",
     "from jimgw.single_event.transforms import SkyFrameToDetectorFrameSkyPositionTransform\n",
@@ -308,7 +270,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -367,18 +329,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Max absolute difference:  1.0436096431476471e-13\n",
-      "Max fractional difference:  1.6856960272093602e-11\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Use much stringent tolerance for this test to ensure equivalence.\n",
     "atol = 1e-13  # Default: 1e-5\n",
@@ -418,7 +371,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "jim",
+   "display_name": "py311_bilby_jim-dev",
    "language": "python",
    "name": "python3"
   },
@@ -432,7 +385,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.13"
+   "version": "3.11.12"
   }
  },
  "nbformat": 4,

--- a/test/unit/test_sky_position_transform.ipynb
+++ b/test/unit/test_sky_position_transform.ipynb
@@ -176,24 +176,33 @@
    "outputs": [],
    "source": [
     "# Compare the greenwich mean sidereal time (GMST) and greenwich apparent sidereal time (GAST).\n",
-    "\n",
+    "from jimgw.gps_times import greenwich_mean_sidereal_time as jim_gmst\n",
     "from bilby_cython.time import greenwich_mean_sidereal_time\n",
     "from astropy.time import Time\n",
     "\n",
     "tol_diff_1 = 0\n",
     "tol_diff_2 = 0\n",
-    "for time in np.random.uniform(1, 10000000, N_SAMPLES):\n",
+    "tol_diff_3 = 0\n",
+    "gps_times = jax.random.uniform(\n",
+    "    jax.random.PRNGKey(42), N_SAMPLES*2, minval=1, maxval=2e9+1234.5678\n",
+    ")\n",
+    "# for time in np.random.uniform(1, 10000000, N_SAMPLES):\n",
+    "for time in gps_times:\n",
     "    gps_time = Time(time, format=\"gps\")\n",
     "    gmst_j = gps_time.sidereal_time(\"mean\", \"greenwich\").rad % (2 * np.pi)\n",
     "    gast_j = gps_time.sidereal_time(\"apparent\", \"greenwich\").rad % (2 * np.pi)\n",
+    "    gmst_jim = jim_gmst(time) % (2 * np.pi)\n",
     "    gmst_b = greenwich_mean_sidereal_time(time) % (2 * np.pi)\n",
     "    tol_diff_1 += jnp.abs(gmst_j - gmst_b)\n",
     "    tol_diff_2 += jnp.abs(gast_j - gmst_b)\n",
+    "    tol_diff_3 += jnp.abs(gmst_jim - gmst_b)\n",
     "\n",
     "mean_diff = tol_diff_1 / N_SAMPLES\n",
     "print(\"Mean difference in GMST: \", mean_diff)\n",
     "mean_diff = tol_diff_2 / N_SAMPLES\n",
-    "print(\"Mean difference in GAST: \", mean_diff)"
+    "print(\"Mean difference in GAST: \", mean_diff)\n",
+    "mean_diff = tol_diff_3 / N_SAMPLES\n",
+    "print(\"Mean difference in new Jim GMST: \", mean_diff)"
    ]
   },
   {
@@ -259,6 +268,15 @@
    "metadata": {},
    "source": [
     "As seen in the above, the source of error in `SkyFrameToDetectorFrameSkyPositionTransform` would be the difference in calculating `gmst`. `Jim` and `bilby` use different algorithms for calculating `gmst`. This introduces an error of the order 1e-5 to `ra`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Update on 2025/05/06:**\n",
+    "With the newly implemented GMST algorithm, the difference is now far below `1e-5`.\n",
+    "In fact, it can reach exactly zero now."
    ]
   },
   {

--- a/test/unit/test_transform.py
+++ b/test/unit/test_transform.py
@@ -904,9 +904,13 @@ class TestSpinAnglesToCartesianSpinTransform:
 
 
 class TestSkyFrameToDetectorFrameSkyPositionTransform:
-    # Since Bilby and Jim use different algorithm for gmst, which
-    # induces errors to RA, and this is the minimum precision that passes
-    RA_ATOL = 5e-5
+    # This was the custom tolerance for RA as Bilby and Jim use different
+    # algorithm to compute gmst, which induces errors to RA, and this 
+    # was the minimum precision that passes. 
+    # In the latter version, Jim has adopted the Bilby/LAL algorithm to
+    # compute gmst, and the agreement is at the level of 0.0, which 
+    # renders this tolerance obsolete.
+    # RA_ATOL = 5e-5
 
     def test_backward_transform(self):
         """
@@ -928,10 +932,7 @@ class TestSkyFrameToDetectorFrameSkyPositionTransform:
             # test the forward transform
             jim_outputs, jacobian = jax.vmap(transform.inverse)(zenith_azimuth)
 
-            # Use the tailored atol for RA
-            assert jnp.allclose(
-                jim_outputs["ra"], bilby_outputs["ra"], atol=self.RA_ATOL
-            )
+            assert jnp.allclose(jim_outputs["ra"], bilby_outputs["ra"])
             assert jnp.allclose(jim_outputs["dec"], bilby_outputs["dec"])
             assert not jnp.isnan(jacobian).any()
 

--- a/test/verify_jit_gmst.py
+++ b/test/verify_jit_gmst.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python
+"""
+This script verifies the JAX implementation of the conversion from GPS time 
+to UTC date and GMST values against the LAL and Bilby implementations, all 
+the way up to year 2500 (and potentially beyond this).
+
+It is done in two parts:
+1. The first part without JIT, which would give an EXACT match with the precomputed values.
+2. The second part with JIT enabled, it would give an error of order 1e-10 s.
+
+There are 10,000,000 pre-computed values stored in the file lal_bilby_utc_gmst.npy, which contains
+    * gps_time: The input GPS time in seconds
+    * lal: LAL computed values
+        * year: Year
+        * month: Month
+        * day: Day
+        * sec: Remaing seconds
+        * gmst: GMST in radians
+    * bilby: Bilby computed values
+        * year: Year
+        * month: Month
+        * day: Day
+        * sec: Remaing seconds
+        * gmst: GMST in radians
+The exact script used to prepare these values is appended as comments.
+
+The gps_time are generated from 1980-01-06 to 2500-12-31.
+Note that the LAL implementation, limited by overflow errors, can only compute up to the year 2038.
+The remaining years till 2500 (and more) are way beyond practical purposes, and are purely for the 
+algorithmic comparison with the Bilby implementation.
+"""
+import time
+import jax
+import jax.numpy as np
+jax.config.update("jax_enable_x64", True)
+jax.config.update("jax_platforms", 'cpu')
+from jimgw.gps_times import gps_to_utc_date, greenwich_mean_sidereal_time as jim_gmst
+
+# This file contains 10 million GPS timestamps of which the UTC dates 
+# and GMST values are computed using LAL and Bilby.
+computed_times = np.load('lal_bilby_utc_gmst.npy')
+
+# This verification is done in chunks as it would apparently take 
+# too much memory to laod and compare all JAX arrays at once.
+chunks = 8
+
+with jax.disable_jit():
+    print('================================')
+    print('Without JIT:')
+    print('================================')
+    start = 0
+    for end in np.linspace(0, 10_000_000 + 1, chunks, dtype=np.int32)[1:]:
+        print(f'================================')
+        print(f'Start index is: {start}')
+        print(f'================================')
+        _computed_times = computed_times[start:end]
+        print(f'Computing {_computed_times.size} samples')
+        start_time = time.time()
+        gps_times = np.asarray(_computed_times['gps_time'])
+        utc_dates = jax.vmap(gps_to_utc_date)(gps_times)
+        gmst_vals = jax.vmap(jim_gmst)(gps_times)
+        print(f"--- Computation takes: {time.time() - start_time:.6f} seconds ---")
+
+        print('For LAL and Bilby:')
+        for item in ('year', 'month', 'day', 'sec', 'gmst'):
+            is_agree = np.where(
+                _computed_times['lal']['year'] != 0,
+                (_computed_times['lal'][item] == _computed_times['bilby'][item]), 
+                True
+            ).all()
+            print(f' * {item} is agree:   {is_agree}')
+
+        print('For Jim and Bilby:')
+        for key, jim_val in zip(('year', 'month', 'day', 'sec', 'gmst'), 
+                                (*utc_dates, gmst_vals)):
+            is_agree = (jim_val == _computed_times["bilby"][key]).all()
+            print(f' * {key} is agree:   {is_agree}')
+        start = end
+
+print('================================')
+print('With JIT:')
+print('================================')
+RTOL = 1e-16
+ATOL = 4e-10
+start = 0
+for end in np.linspace(0, 10_000_000 + 1, chunks, dtype=np.int32)[1:]:
+    print(f'================================')
+    print(f'Start index is: {start}')
+    print(f'================================')
+    _computed_times = computed_times[start:end]
+    print(f'Computing {_computed_times.size} samples')
+    start_time = time.time()
+    gps_times = np.asarray(_computed_times['gps_time'])
+    utc_dates = jax.vmap(gps_to_utc_date)(gps_times)
+    gmst_vals = jax.vmap(jim_gmst)(gps_times)
+    print(f"--- Computation takes: {time.time() - start_time:.6f} seconds ---")
+
+    print('For Jim and Bilby:')
+    for key, jim_val in zip(('year', 'month', 'day', 'sec', 'gmst'), 
+                            (*utc_dates, gmst_vals)):
+        is_agree = jax.numpy.allclose(
+            jim_val, _computed_times["bilby"][key], rtol=RTOL, atol=ATOL)
+        print(f' * {key} is agree:   {is_agree}')
+    start = end
+
+"""
+Final remarks:
+There are some additional tests that are not shown here.
+
+The JAX implementation is tested for near GPS times at 0.0, from range -1000 to +1000, 
+    * If one assumes int64, then all results are equivalent.
+    * If one assumes float64, and with negative GPS times, after mod(2π), there is always a constant offset by -0.00014584 rad.
+"""
+
+
+"""
+#######################
+# prepare_UTC_GMST.py #
+#######################
+#/usr/bin/env python
+'''
+The purpose of this script is to prepare a set of
+UTC dates from LAL and Bilby for comparison with Jim.
+
+The key outputs of this script are:
+1. The GPS timestamp
+2. The UTC date from LAL and Bilby
+3. The GMST from LAL and Bilby
+
+Note: This script can quite some time to run.
+'''
+import time
+from calendar import timegm
+import numpy as np
+
+from lal import GPSToUTC, \
+    GreenwichMeanSiderealTime as LAL_gmst
+from bilby_cython.time import \
+    gps_time_to_utc as gps_time_to_utc, \
+    greenwich_mean_sidereal_time as bilby_gmst
+
+SIZE = 10_000_000
+# SIZE = 10
+# The test range is the designed time range of the
+# Jim UTC date implementation.
+start_time = timegm(time.strptime('1980-01-06', '%Y-%m-%d'))
+end_time = timegm(time.strptime('2500-12-31', '%Y-%m-%d'))
+print(f'{start_time = }, and {end_time = }.')
+# Note that the end time is too far in the future and
+# since no one can predict precisely when will leap seconds
+# be added, this implies that by no means will the UTC time
+# be accurate or valid. This is a mere algorithmic test.
+
+def compute_seconds_from_utc_date(hour: int, min: int, sec: int) -> int:
+    return sec + min * 60 + hour * 3600
+
+rng = np.random.default_rng(seed=1234)
+gps_times = np.geomspace(start_time, end_time, SIZE, dtype=np.int64)
+print('Here are the machine precision limits:')
+print(np.iinfo(np.int32), np.iinfo(np.int64))
+
+none_tuple = tuple([0] * 9)
+
+start_time = time.time()
+results = []
+for gps_time in gps_times:
+    bilby_utc = gps_time_to_utc(gps_time)
+    bilby_sec = compute_seconds_from_utc_date(
+        bilby_utc.hour, bilby_utc.minute, bilby_utc.second)
+    bilby_gmst_val = bilby_gmst(gps_time)
+    try:
+    # Note that LAL implementation has an "upper limit" of year 2038
+    # see: https://lscsoft.docs.ligo.org/lalsuite/lal/_x_l_a_l_civil_time_8c_source.html#l00276
+        lal_utc = GPSToUTC(gps_time)
+        lal_sec = compute_seconds_from_utc_date(
+            lal_utc[3], lal_utc[4], lal_utc[5])
+        lal_gmst_val = LAL_gmst(gps_time)
+    except OverflowError:
+        lal_utc = none_tuple
+        lal_sec = 0
+        lal_gmst = 0.0
+    except RuntimeError:
+        print(gps_time)
+
+    results.append(
+        (gps_time, (lal_utc[0], lal_utc[1], lal_utc[2], lal_sec, lal_gmst_val),
+         (bilby_utc.year, bilby_utc.month, bilby_utc.day, bilby_sec, bilby_gmst_val))
+    )
+
+print(f"--- {time.time() - start_time:.6f} seconds ---")
+
+np_results = np.array(results, dtype=[
+    ('gps_time', np.int64),
+    ('lal', [('year', np.int32), ('month', np.int32), ('day', np.int32), ('sec', np.int32), ('gmst', np.float64)]),
+    ('bilby', [('year', np.int64), ('month', np.int64), ('day', np.int64), ('sec', np.int64), ('gmst', np.float64)])
+])
+np.save('lal_bilby_utc_gmst.npy', np_results)
+"""


### PR DESCRIPTION
In a nutshell, this PR 
1. introduces functions for computing the UTC datetime and Greenwich mean sidereal time that are fully jittable; 
2. allows `gmst` to be computed on the fly, thereby making the antenna pattern faithful at `trigger_time + t_c`;
3. replaces `gmst`, `t_c` and `trigger_time` with `geocent_time` as input for `fd_response`, which also addresses the remaining issue in #213.

### Purpose
The original purpose was to calculate a more accurate `gmst` within the likelihood function, which will then be fed into the `detector.fd_response` function, because the current implementation does not take into account the time shifts (`t_c`) that are being sampled, see [here](../src/jimgw/single_event/likelihood.py#175). 

Moreover, a jittable `gmst` function will be useful for third-generation studies where the antenna pattern can no longer be assumed to be static.

### Valid range
It is tested against the LAL implementation (link here) and produces exactly the same outcome until the LAL function overflows (at around year 2035). Then it is also tested against the current `Cython` implementation in `Bilby` (link here), which again produces the same results until year 2500, which is far beyond any practical purpose.
(See [`verify_jit_gmst`](https://github.com/kazewong/jim/blob/fix-gmst-in-fd_response/test/verify_jit_gmst.py) for more details)

This level of agreement also eliminates the differences found in our transform tests for `ra`, which was approximately `1e-5 radian`; converting it back to time yields about 0.1375 seconds.

**TODO:**
- [x] Propagate this to the heterodyned likelihood function.

This PR should be merged after #213. 

### The old plan
Given that `t_c` is typically small for most current cases, this PR adopts a temporary fix as follows:
```python
# From:
params["gmst"] = self.gmst
# To:
params["gmst"] = self.gmst + params["t_c"] / HR_TO_SEC * HR_TO_RAD
```
This assumes that the `t_c` is small enough that more accurate computations are unnecessary.

### Alternative approaches
1. Use `astropy` to recompute:
    * `params["gmst"] = Time(self.gmst + params["t_c”], format=‘gps’).sidereal_time("mean", "greenwich").rad`
    * This one suffers from the issue that `astropy` and `Jax` array are incompatible
    * Converting it to `numpy` array will lead to in tracable `Jax` array
3. Use the `bilby`/`LAL` GMST calculations
    * This one relies on the `delta_time` in `datetime` package, which is not compatible with `Jax` arrays, not even with `list`
    * A way out would be to use the (very) new [`jax-datetime` package](https://github.com/google/jax-datetime), the only issue is it being an additional package, and it looks a bit too new. More crucially, it does not compute the necessary years, months, and days.
5. Another approximation in other packages
    * There is an approximate scheme to compute GMST in other packages that use `Jax` (see [GWFish](https://github.com/janosch314/GWFish/blob/0e215a67b781efaf9ecde7d3a0f6f7d90e654fb5/GWFish/modules/detection.py#L232-L234) and [gwfast](https://github.com/CosmoStatGW/gwfast/blob/b27e8ad6c0317e323b66c755cc0262981ba552be/gwfast/gwfastUtils.py#L758-L770))
    * `gmst = jnp.mod(9.533088395981618 + (t_GPS - 1126260000.) / 3600. * 24. / SIDEREALDAY, 24.)`
    
**Any opinion/suggestions are welcome!**