### PR TITLE
Fix parameters order during initialisation

### DIFF
--- a/src/jimgw/jim.py
+++ b/src/jimgw/jim.py
@@ -1,6 +1,5 @@
 import jax
 import jax.numpy as jnp
-from collections import OrderedDict
 from flowMC.resource_strategy_bundle.RQSpline_MALA_PT import RQSpline_MALA_PT_Bundle
 from flowMC.resource.buffers import Buffer
 from flowMC.Sampler import Sampler
@@ -163,8 +162,8 @@ class Jim(object):
                 jax.tree.map(lambda x: jnp.isfinite(x), initial_position),
             ).all():
                 non_finite_index = jnp.where(
-                    jnp.any(
-                        ~jax.tree.reduce(
+                    jnp.all(
+                        jax.tree.reduce(
                             jnp.logical_and,
                             jax.tree.map(lambda x: jnp.isfinite(x), initial_position),
                         ),
@@ -176,9 +175,7 @@ class Jim(object):
                 guess = self.prior.sample(subkey, self.sampler.n_chains)
                 for transform in self.sample_transforms:
                     guess = jax.vmap(transform.forward)(guess)
-                guess = jnp.array(
-                    jax.tree.leaves(OrderedDict({key: guess[key] for key in self.parameter_names}))
-                ).T
+                guess = jnp.array([guess[key] for key in self.parameter_names]).T
                 finite_guess = jnp.where(
                     jnp.all(jax.tree.map(lambda x: jnp.isfinite(x), guess), axis=1)
                 )[0]

--- a/src/jimgw/jim.py
+++ b/src/jimgw/jim.py
@@ -162,8 +162,8 @@ class Jim(object):
                 jax.tree.map(lambda x: jnp.isfinite(x), initial_position),
             ).all():
                 non_finite_index = jnp.where(
-                    jnp.all(
-                        jax.tree.reduce(
+                    jnp.any(
+                        ~jax.tree.reduce(
                             jnp.logical_and,
                             jax.tree.map(lambda x: jnp.isfinite(x), initial_position),
                         ),

--- a/src/jimgw/jim.py
+++ b/src/jimgw/jim.py
@@ -1,5 +1,6 @@
 import jax
 import jax.numpy as jnp
+from collections import OrderedDict
 from flowMC.resource_strategy_bundle.RQSpline_MALA_PT import RQSpline_MALA_PT_Bundle
 from flowMC.resource.buffers import Buffer
 from flowMC.Sampler import Sampler
@@ -176,7 +177,7 @@ class Jim(object):
                 for transform in self.sample_transforms:
                     guess = jax.vmap(transform.forward)(guess)
                 guess = jnp.array(
-                    jax.tree.leaves({key: guess[key] for key in self.parameter_names})
+                    jax.tree.leaves(OrderedDict({key: guess[key] for key in self.parameter_names}))
                 ).T
                 finite_guess = jnp.where(
                     jnp.all(jax.tree.map(lambda x: jnp.isfinite(x), guess), axis=1)

--- a/src/jimgw/single_event/likelihood.py
+++ b/src/jimgw/single_event/likelihood.py
@@ -2,6 +2,7 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 import numpy.typing as npt
+from collections import OrderedDict
 from astropy.time import Time
 from flowMC.strategy.optimization import AdamOptimization
 from jax.scipy.special import logsumexp
@@ -635,7 +636,7 @@ class HeterodynedTransientLikelihoodFD(TransientLikelihoodFD):
             for transform in sample_transforms:
                 guess = jax.vmap(transform.forward)(guess)
             guess = jnp.array(
-                jax.tree.leaves({key: guess[key] for key in parameter_names})
+                jax.tree.leaves(OrderedDict({key: guess[key] for key in parameter_names}))
             ).T
             finite_guess = jnp.where(
                 jnp.all(jax.tree.map(lambda x: jnp.isfinite(x), guess), axis=1)

--- a/src/jimgw/single_event/likelihood.py
+++ b/src/jimgw/single_event/likelihood.py
@@ -75,15 +75,15 @@ class TransientLikelihoodFD(SingleEventLikelihood):
             # make sure the psd and data are consistent
             assert (freq_0 == freq_1).all(), \
                 f"The {detector.name} data and PSD must have same frequencies"
-                
+
         # make sure all detectors are consistent
         assert all([(freqs[0] == freq).all() for freq in freqs]), \
             "The detectors must have the same frequency grid"
-            
+
         self.frequencies = freqs[0]  # type: ignore
         self.datas = datas
         self.psds = psds
-        
+
         self.waveform = waveform
         self.trigger_time = trigger_time
         self.gmst = (
@@ -621,8 +621,8 @@ class HeterodynedTransientLikelihoodFD(TransientLikelihoodFD):
             jnp.logical_and, jax.tree.map(lambda x: jnp.isfinite(x), initial_position)
         ).all():
             non_finite_index = jnp.where(
-                jnp.all(
-                    jax.tree.reduce(
+                jnp.any(
+                    ~jax.tree.reduce(
                         jnp.logical_and,
                         jax.tree.map(lambda x: jnp.isfinite(x), initial_position),
                     ),

--- a/src/jimgw/single_event/likelihood.py
+++ b/src/jimgw/single_event/likelihood.py
@@ -2,7 +2,6 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 import numpy.typing as npt
-from collections import OrderedDict
 from astropy.time import Time
 from flowMC.strategy.optimization import AdamOptimization
 from jax.scipy.special import logsumexp
@@ -622,8 +621,8 @@ class HeterodynedTransientLikelihoodFD(TransientLikelihoodFD):
             jnp.logical_and, jax.tree.map(lambda x: jnp.isfinite(x), initial_position)
         ).all():
             non_finite_index = jnp.where(
-                jnp.any(
-                    ~jax.tree.reduce(
+                jnp.all(
+                    jax.tree.reduce(
                         jnp.logical_and,
                         jax.tree.map(lambda x: jnp.isfinite(x), initial_position),
                     ),
@@ -635,9 +634,7 @@ class HeterodynedTransientLikelihoodFD(TransientLikelihoodFD):
             guess = prior.sample(subkey, popsize)
             for transform in sample_transforms:
                 guess = jax.vmap(transform.forward)(guess)
-            guess = jnp.array(
-                jax.tree.leaves(OrderedDict({key: guess[key] for key in parameter_names}))
-            ).T
+            guess = jnp.array([guess[key] for key in parameter_names]).T
             finite_guess = jnp.where(
                 jnp.all(jax.tree.map(lambda x: jnp.isfinite(x), guess), axis=1)
             )[0]

--- a/src/jimgw/transforms.py
+++ b/src/jimgw/transforms.py
@@ -86,7 +86,6 @@ class NtoNTransform(NtoMTransform):
         transform_params = dict((key, x_copy[key]) for key in self.name_mapping[0])
         output_params = self.transform_func(transform_params)
         jacobian = jax.jacfwd(self.transform_func)(transform_params)
-        # No need to use OrderedDict for determinant
         jacobian = jnp.array(jax.tree.leaves(jacobian))
         jacobian = jnp.log(
             jnp.absolute(jnp.linalg.det(jacobian.reshape(self.n_dim, self.n_dim)))
@@ -126,7 +125,6 @@ class BijectiveTransform(NtoNTransform):
         transform_params = dict((key, y_copy[key]) for key in self.name_mapping[1])
         output_params = self.inverse_transform_func(transform_params)
         jacobian = jax.jacfwd(self.inverse_transform_func)(transform_params)
-        # No need to use OrderedDict for determinant
         jacobian = jnp.array(jax.tree.leaves(jacobian))
         jacobian = jnp.log(
             jnp.absolute(jnp.linalg.det(jacobian.reshape(self.n_dim, self.n_dim)))
@@ -192,7 +190,6 @@ class ConditionalBijectiveTransform(BijectiveTransform):
             key1: {key2: jacobian[key1][key2] for key2 in self.name_mapping[0]}
             for key1 in self.name_mapping[1]
         }
-        # No need to use OrderedDict for determinant
         jacobian = jnp.array(jax.tree.leaves(jacobian_copy))
         jacobian = jnp.log(
             jnp.absolute(jnp.linalg.det(jacobian.reshape(self.n_dim, self.n_dim)))
@@ -219,7 +216,6 @@ class ConditionalBijectiveTransform(BijectiveTransform):
             key1: {key2: jacobian[key1][key2] for key2 in self.name_mapping[1]}
             for key1 in self.name_mapping[0]
         }
-        # No need to use OrderedDict for determinant
         jacobian = jnp.array(jax.tree.leaves(jacobian_copy))
         jacobian = jnp.log(
             jnp.absolute(jnp.linalg.det(jacobian.reshape(self.n_dim, self.n_dim)))

--- a/src/jimgw/transforms.py
+++ b/src/jimgw/transforms.py
@@ -86,6 +86,7 @@ class NtoNTransform(NtoMTransform):
         transform_params = dict((key, x_copy[key]) for key in self.name_mapping[0])
         output_params = self.transform_func(transform_params)
         jacobian = jax.jacfwd(self.transform_func)(transform_params)
+        # No need to use OrderedDict for determinant
         jacobian = jnp.array(jax.tree.leaves(jacobian))
         jacobian = jnp.log(
             jnp.absolute(jnp.linalg.det(jacobian.reshape(self.n_dim, self.n_dim)))
@@ -125,6 +126,7 @@ class BijectiveTransform(NtoNTransform):
         transform_params = dict((key, y_copy[key]) for key in self.name_mapping[1])
         output_params = self.inverse_transform_func(transform_params)
         jacobian = jax.jacfwd(self.inverse_transform_func)(transform_params)
+        # No need to use OrderedDict for determinant
         jacobian = jnp.array(jax.tree.leaves(jacobian))
         jacobian = jnp.log(
             jnp.absolute(jnp.linalg.det(jacobian.reshape(self.n_dim, self.n_dim)))
@@ -190,6 +192,7 @@ class ConditionalBijectiveTransform(BijectiveTransform):
             key1: {key2: jacobian[key1][key2] for key2 in self.name_mapping[0]}
             for key1 in self.name_mapping[1]
         }
+        # No need to use OrderedDict for determinant
         jacobian = jnp.array(jax.tree.leaves(jacobian_copy))
         jacobian = jnp.log(
             jnp.absolute(jnp.linalg.det(jacobian.reshape(self.n_dim, self.n_dim)))
@@ -216,6 +219,7 @@ class ConditionalBijectiveTransform(BijectiveTransform):
             key1: {key2: jacobian[key1][key2] for key2 in self.name_mapping[1]}
             for key1 in self.name_mapping[0]
         }
+        # No need to use OrderedDict for determinant
         jacobian = jnp.array(jax.tree.leaves(jacobian_copy))
         jacobian = jnp.log(
             jnp.absolute(jnp.linalg.det(jacobian.reshape(self.n_dim, self.n_dim)))


### PR DESCRIPTION
As explained in this [GitHub issue](https://github.com/jax-ml/jax/issues/4085#issuecomment-1186908662), most `jax.tree` functions will shuffle the order of dictionary keys to alphabetical order.

This will cause unexpected behaviours if `dict.values()` (or similar functions) is then called upon the new dictionary, and the order of which is assumed to match that before the `tree` function, ***e.g.*** in [here](https://github.com/kazewong/jim/blob/90a6d519c937fd2e9176f9f358988cafdb71dc1b/). 

This PR address the issue by creating the initial points with list comprehension (in favour of the old plan), skipping the dictionary and the problematic tree.leaves entirely. 

**The old plan**
This PR aims to address this issue, except for places where the outcome is immediately followed by summation or determinants (`jnp.sum`, `jnp.det`, `jnp.reduce`, etc), in which case the ordering does not matter.