### PR TITLE
Adding back `inject_signal` function

### DIFF
--- a/src/jimgw/constants.py
+++ b/src/jimgw/constants.py
@@ -1,3 +1,4 @@
+import jax.numpy as np
 from astropy.constants import pc  # type: ignore TODO: fix astropy stubs
 import astropy.units as u  # type: ignore
 
@@ -21,4 +22,9 @@ EARTH_SEMI_MAJOR_AXIS = 6378137.0  # for ellipsoid model of Earth, in m
 EARTH_SEMI_MINOR_AXIS = 6356752.314  # in m
 
 DAYSID_SI = 86164.09053133354
-DAYJUL_SI = 86400.0
+DAYJUL_SI: int = 86400
+
+DEG_TO_RAD = np.pi / 180
+
+HR_TO_RAD = 2 * np.pi / 24
+HR_TO_SEC: int = 3600

--- a/src/jimgw/single_event/data.py
+++ b/src/jimgw/single_event/data.py
@@ -13,9 +13,6 @@ import logging
 import jax
 import jax.numpy as jnp
 
-
-DEG_TO_RAD = np.pi / 180
-
 # TODO: Need to expand this list. Currently it is only O3.
 asd_file_dict = {
     "H1": "https://dcc.ligo.org/public/0169/P2000251/001/O3-H1-C01_CLEAN_SUB60HZ-1251752040.0_sensitivity_strain_asd.txt",  # noqa: E501

--- a/src/jimgw/single_event/detector.py
+++ b/src/jimgw/single_event/detector.py
@@ -10,10 +10,8 @@ from scipy.interpolate import interp1d
 from jimgw.single_event import data as jd
 from typing import Optional
 
-from jimgw.constants import C_SI, EARTH_SEMI_MAJOR_AXIS, EARTH_SEMI_MINOR_AXIS
+from jimgw.constants import C_SI, EARTH_SEMI_MAJOR_AXIS, EARTH_SEMI_MINOR_AXIS, DEG_TO_RAD
 from jimgw.single_event.wave import Polarization
-
-DEG_TO_RAD = jnp.pi / 180
 
 # TODO: Need to expand this list. Currently it is only O3.
 asd_file_dict = {

--- a/src/jimgw/single_event/detector.py
+++ b/src/jimgw/single_event/detector.py
@@ -2,12 +2,11 @@ from abc import ABC, abstractmethod
 
 import jax
 import jax.numpy as jnp
-import numpy as np
+from numpy import loadtxt
 import requests
-from jaxtyping import Array, Float, PRNGKeyArray, jaxtyped
+from jaxtyping import Array, Float, jaxtyped
 from beartype import beartype as typechecker
 from scipy.interpolate import interp1d
-from scipy.signal.windows import tukey
 from jimgw.single_event import data as jd
 from typing import Optional
 
@@ -421,14 +420,13 @@ class GroundBased2G(Detector):
             url = asd_file_dict[self.name]
             data = requests.get(url)
             open(self.name + ".txt", "wb").write(data.content)
-            f, asd_vals = np.loadtxt(self.name + ".txt", unpack=True)
+            f, asd_vals = loadtxt(self.name + ".txt", unpack=True)
             psd_vals = asd_vals ** 2
         else:
-            f, psd_vals = np.loadtxt(psd_file, unpack=True)
+            f, psd_vals = loadtxt(psd_file, unpack=True)
 
         psd = interp1d(f, psd_vals, fill_value=(psd_vals[0], psd_vals[-1]), bounds_error=False)(freqs)  # type: ignore
-        psd = jnp.array(psd)
-        return psd
+        return jnp.array(psd)
 
     def set_data(self, data: jd.Data | Array, **kws) -> None:
         """Add data to the detector.

--- a/src/jimgw/single_event/detector.py
+++ b/src/jimgw/single_event/detector.py
@@ -374,7 +374,7 @@ class GroundBased2G(Detector):
                 jnp.cos(theta),
             ]
         )
-        return jnp.dot(omega, delta_d) / C_SI
+        return jnp.einsum('i...,i->...', omega, delta_d) / C_SI
 
     def antenna_pattern(self, ra: Float, dec: Float, psi: Float, gmst: Float) -> dict[str, Float]:
         """Compute antenna patterns for polarizations at specified sky location.
@@ -398,7 +398,7 @@ class GroundBased2G(Detector):
         for polarization in self.polarization_mode:
             wave_tensor = polarization.tensor_from_sky(ra, dec, psi, gmst)
             antenna_patterns[polarization.name] = jnp.einsum(
-                "ij,ij->", detector_tensor, wave_tensor
+                "ij,ij...->...", detector_tensor, wave_tensor
             )
 
         return antenna_patterns

--- a/src/jimgw/single_event/likelihood.py
+++ b/src/jimgw/single_event/likelihood.py
@@ -15,10 +15,8 @@ from jimgw.single_event.detector import Detector
 from jimgw.utils import log_i0
 from jimgw.single_event.waveform import Waveform
 from jimgw.transforms import BijectiveTransform, NtoMTransform
+from jimgw.constants import HR_TO_RAD, HR_TO_SEC
 import logging
-
-HR_TO_RAD = 2 * np.pi / 24
-HR_TO_SEC = 3600
 
 
 class SingleEventLikelihood(LikelihoodBase):

--- a/src/jimgw/single_event/likelihood.py
+++ b/src/jimgw/single_event/likelihood.py
@@ -171,7 +171,10 @@ class TransientLikelihoodFD(SingleEventLikelihood):
         """Evaluate the likelihood for a given set of parameters.
         """
         frequencies = self.frequencies
-        params["gmst"] = self.gmst
+        # params["gmst"] = self.gmst
+        # Note: How about we sample in "geocent_time" instead?
+        _gmst = Time(self.trigger_time + params["t_c"], format="gps")
+        params["gmst"] = _gmst.sidereal_time("apparent", "greenwich").rad
         # adjust the params due to different marginalzation scheme
         params = self.param_func(params)
         # adjust the params due to fixing parameters

--- a/src/jimgw/single_event/likelihood.py
+++ b/src/jimgw/single_event/likelihood.py
@@ -17,6 +17,9 @@ from jimgw.single_event.waveform import Waveform
 from jimgw.transforms import BijectiveTransform, NtoMTransform
 import logging
 
+HR_TO_RAD = 2 * np.pi / 24
+HR_TO_SEC = 3600
+
 
 class SingleEventLikelihood(LikelihoodBase):
     detectors: list[Detector]
@@ -85,7 +88,7 @@ class TransientLikelihoodFD(SingleEventLikelihood):
 
         self.waveform = waveform
         self.gmst = (
-            Time(trigger_time, format="gps").sidereal_time("apparent",
+            Time(trigger_time, format="gps").sidereal_time("mean",
                                                            "greenwich").rad
         )
 
@@ -173,8 +176,7 @@ class TransientLikelihoodFD(SingleEventLikelihood):
         frequencies = self.frequencies
         # params["gmst"] = self.gmst
         # Note: How about we sample in "geocent_time" instead?
-        _gmst = Time(self.trigger_time + params["t_c"], format="gps")
-        params["gmst"] = _gmst.sidereal_time("apparent", "greenwich").rad
+        params["gmst"] = self.gmst + params["t_c"] / HR_TO_SEC * HR_TO_RAD
         # adjust the params due to different marginalzation scheme
         params = self.param_func(params)
         # adjust the params due to fixing parameters

--- a/src/jimgw/single_event/wave.py
+++ b/src/jimgw/single_event/wave.py
@@ -1,7 +1,7 @@
 # Credit some part of the source code from bilby
 
 import equinox as eqx
-import jax.numpy as jnp
+import jax.numpy as np
 from jaxtyping import Array, Float
 
 KNOWN_POLS = "pcxybl"
@@ -32,21 +32,22 @@ class Polarization(eqx.Module):
         defined by orthonormal vectors (x, y) in arbitrary Cartesian
         coordinates.
         """
+        outer_fmt = "i...,j...->ij..."
         if self.name == "p":
-            return jnp.einsum("i,j->ij", x, x) - jnp.einsum("i,j->ij", y, y)
+            return np.einsum(outer_fmt, x, x) - np.einsum(outer_fmt, y, y)
         elif self.name == "c":
-            return jnp.einsum("i,j->ij", x, y) + jnp.einsum("i,j->ij", y, x)
+            return np.einsum(outer_fmt, x, y) + np.einsum(outer_fmt, y, x)
         elif self.name == "x":
-            z = jnp.cross(x, y)
-            return jnp.einsum("i,j->ij", x, z) + jnp.einsum("i,j->ij", z, x)
+            z = np.cross(x, y)
+            return np.einsum(outer_fmt, x, z) + np.einsum(outer_fmt, z, x)
         elif self.name == "y":
-            z = jnp.cross(x, y)
-            return jnp.einsum("i,j->ij", y, z) + jnp.einsum("i,j->ij", z, y)
+            z = np.cross(x, y)
+            return np.einsum(outer_fmt, y, z) + np.einsum(outer_fmt, z, y)
         elif self.name == "b":
-            return jnp.einsum("i,j->ij", x, x) + jnp.einsum("i,j->ij", y, y)
+            return np.einsum(outer_fmt, x, x) + np.einsum(outer_fmt, y, y)
         elif self.name == "l":
-            z = jnp.cross(x, y)
-            return jnp.einsum("i,j->ij", z, z)
+            z = np.cross(x, y)
+            return np.einsum(outer_fmt, z, z)
         else:
             raise ValueError(f"unrecognized polarization {self.name}")
 
@@ -72,19 +73,19 @@ class Polarization(eqx.Module):
         tensor : array
             3x3 polarization tensor.
         """
-        gmst = jnp.mod(gmst, 2 * jnp.pi)
+        gmst = np.mod(gmst, 2 * np.pi)
         phi = ra - gmst
-        theta = jnp.pi / 2 - dec
+        theta = np.pi / 2 - dec
 
-        u = jnp.array(
+        u = np.array(
             [
-                jnp.cos(phi) * jnp.cos(theta),
-                jnp.cos(theta) * jnp.sin(phi),
-                -jnp.sin(theta),
+                np.cos(phi) * np.cos(theta),
+                np.cos(theta) * np.sin(phi),
+                -np.sin(theta),
             ]
         )
-        v = jnp.array([-jnp.sin(phi), jnp.cos(phi), 0])
-        m = -u * jnp.sin(psi) - v * jnp.cos(psi)
-        n = -u * jnp.cos(psi) + v * jnp.sin(psi)
+        v = np.array([-np.sin(phi), np.cos(phi), phi*0.0])
+        m = -u * np.sin(psi) - v * np.cos(psi)
+        n = -u * np.cos(psi) + v * np.sin(psi)
 
         return self.tensor_from_basis(m, n)


### PR DESCRIPTION
As the title says, this PR adds back the `inject_signal` function, which was removed in #172.

Along with other things:
1. Promote antenna pattern calculations to support array input
2. Relocate constants
3. Add functions to compute whitened strains