### PR TITLE
Enforce float64 requirement in Detector initialisation

### DIFF
--- a/src/jimgw/core/single_event/detector.py
+++ b/src/jimgw/core/single_event/detector.py
@@ -188,7 +188,7 @@ class Detector(ABC):
         return self._sliced_psd
 
     def __init__(self):
-        if not jax.config.jax_enable_x64:
+        if not jax.config.read("jax_enable_x64"):
             raise RuntimeError(
                 "Detector requires JAX to run in 64-bit (float64) mode, "
                 "but jax_enable_x64 is currently False.\n\n"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling by notifying users if 64-bit mode is not enabled when creating detectors.
- **New Features**
	- Added a check to ensure 64-bit floating point precision is enabled before using detector classes, providing clear instructions if not.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->