### PR TITLE
Creating container files for deployment

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,0 +1,56 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+# GitHub recommends pinning actions to a commit SHA.
+# To get a newer version, you will need to update the SHA.
+# You can also reference a tag or branch, but the action may change without warning.
+
+name: Publish Docker image
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  push_to_registry:
+    name: Push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+      attestations: write
+      id-token: write
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: my-docker-hub-namespace/my-docker-hub-repository
+
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
+        with:
+          context: .
+          file: ./containers/Containerfile.cuda
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: index.docker.io/my-docker-hub-namespace/my-docker-hub-repository
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/containers/Containerfile.cpu
+++ b/containers/Containerfile.cpu
@@ -1,0 +1,15 @@
+FROM ghcr.io/astral-sh/uv:python3.12-bookworm as uv-source
+FROM nvcr.io/nvidia/cuda:12.9.1-base-ubuntu20.04
+
+# Copy the entire filesystem from uv image
+COPY --from=uv-source / /
+
+WORKDIR /home
+
+RUN git clone https://github.com/kazewong/jim.git
+
+WORKDIR /home/jim
+RUN git checkout jim-dev
+
+# Run uv sync
+RUN uv sync --extra pipeline

--- a/containers/Containerfile.cuda
+++ b/containers/Containerfile.cuda
@@ -1,0 +1,15 @@
+FROM ghcr.io/astral-sh/uv:python3.12-bookworm as uv-source
+FROM nvcr.io/nvidia/cuda:12.9.1-base-ubuntu20.04
+
+# Copy the entire filesystem from uv image
+COPY --from=uv-source / /
+
+WORKDIR /home
+
+RUN git clone https://github.com/kazewong/jim.git
+
+WORKDIR /home/jim
+RUN git checkout jim-dev
+
+# Run uv sync
+RUN uv sync --extra cuda --extra pipeline


### PR DESCRIPTION
This PR introduces two container files and a github action to build and upload jim's image in a Nviida + uv image to Docker.

**The following message is generated by copilot**

This pull request introduces a new GitHub Actions workflow to publish Docker images and adds two container files (`Containerfile.cpu` and `Containerfile.cuda`) for building Docker images with CPU and CUDA support. The most important changes are summarized below:

### New GitHub Actions Workflow:
* Added a workflow in `.github/workflows/container.yml` to automate the publishing of Docker images to Docker Hub. This includes steps for logging into Docker Hub, extracting metadata, building and pushing the Docker image, and generating artifact attestations.

### Container File Additions:
* [`containers/Containerfile.cpu`](diffhunk://#diff-3cd781819560b33e0aea83fb977987482ef1ef0ab465d46b4cec3fc19b63eb93R1-R15): Added a Dockerfile for building a container with CPU support. It uses a base image from NVIDIA's CUDA repository, clones a GitHub repository, checks out the `jim-dev` branch, and runs a `uv sync` command with the `pipeline` option.
* [`containers/Containerfile.cuda`](diffhunk://#diff-09c90a4f855433e927c05f212b77e3bf6bd9a7951afd66ba725ecdcf56d009e7R1-R15): Added a Dockerfile for building a container with CUDA support. It follows a similar structure to `Containerfile.cpu` but includes an additional `--extra cuda` option in the `uv sync` command.